### PR TITLE
Match all alphanumeric function names

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -702,7 +702,7 @@ syn match terraBraces        "[{}\[\]]"
 syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStringInterp
 syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction contained
 "" TODO match keywords here, not a-z+
-syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction contained
+syn region terraValueFunction matchgroup=terraBrackets start=/[0-9a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction contained
 
 hi def link terraComment           Comment
 hi def link terraTodo              Todo


### PR DESCRIPTION
Functions like `base64encode` contain characters other than the alphabet. This change captures that fact.