### PR TITLE
Indent function argument newline continuation

### DIFF
--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -28,7 +28,7 @@ function! TerraformIndent(lnum)
   let thisindent = previndent
 
   " block open?
-  if prevline =~ '[\[{]\s*$'
+  if prevline =~ '[\[{\(]\s*$'
     let thisindent += &sw
   endif
 
@@ -36,7 +36,7 @@ function! TerraformIndent(lnum)
   let thisline = substitute(getline(a:lnum), '//.*$', '', '')
 
   " block close?
-  if thisline =~ '^\s*[\]}]'
+  if thisline =~ '^\s*[\)\]}]'
     let thisindent -= &sw
   endif
 


### PR DESCRIPTION
Indent function argument newline continuation.
This makes it easy to follow when using several interpolations

```hcl
resource "foo_bar" "baz" {
  count = "${
    length(
      var.azs,
    )
  }"
```

