### PR TITLE
Add heredoc support

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -848,6 +848,7 @@ syn match terraBraces        "[{}\[\]]"
 """ we may also want to pass \\" into a function to escape quotes.
 syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStringInterp
 syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction,terraValueVarSubscript contained
+syn region terraHereDocText   start=/<<\z([A-Z]\+\)/ end=/^\z1/ contains=terraStringInterp
 "" TODO match keywords here, not a-z+
 syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
 " User variables or module outputs can be lists or maps, and accessed with
@@ -874,6 +875,7 @@ hi def link terraValueBool         Boolean
 hi def link terraValueDec          Number
 hi def link terraValueHexaDec      Number
 hi def link terraValueString       String
+hi def link terraHereDocText       String
 hi def link terraProvisioner       Structure
 hi def link terraProvisionerName   String
 hi def link terraModule            Structure


### PR DESCRIPTION
This pull request adds support for recognizing heredocs.

According to the docs here doc is:

> Multiline strings can use shell-style "here doc" syntax, with the string starting with a marker like <<EOF and then the string ending with EOF on a line of its own. The lines of the string and the end marker must not be indented.

```hcl
resource "aws_instance" "web" {
  # ...

  provisioner "local-exec" {
    command = <<CMD
echo ${aws_instance.web.private_ip} >> private_ips.txt && \
echo some other command
CMD
  }
}
```

This fixes #25.