### PR TITLE
Set spacebar remapping off by default, per README

### DIFF
--- a/after/ftplugin/terraform.vim
+++ b/after/ftplugin/terraform.vim
@@ -4,6 +4,7 @@ endif
 
 if !exists('g:terraform_remap_spacebar')
   let g:terraform_align = 0
+  let g:terraform_remap_spacebar = 0
 endif
 
 if g:terraform_align && exists(':Tabularize')


### PR DESCRIPTION
Per the README, spacebar remapping should be disabled by default, but it's not. You can see that spacebar remapping is currently enabled by default by checking your spacebar mappings with `:map` before and after installing this plugin.