### PR TITLE
Add automated unit tests of syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /doc/tags
+/vader.vim

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: vim
+
+before_script: |
+  git clone https://github.com/junegunn/vader.vim.git
+script: |
+  make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+TERM=xterm
+HOME=/dev/null
+VIMINIT=
+
+check: vader.vim
+	bash -c 'vim -Nu <( echo "set rtp+=vader.vim,.,./after | filetype plugin indent on | syntax enable") -c "silent Vader! test/*"'
+
+vader.vim:
+	git clone https://github.com/junegunn/vader.vim.git

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1,0 +1,36 @@
+Given terraform (user maps):
+  resource "aws_subnet" "dmz" {
+    cidr_block = "${var.dmz_subnet["${count.index}"]}" # Comment
+  }
+
+Execute (syntax is good):
+  AssertEqual 'terraStringInterp', SyntaxOf('count.index')
+
+  " Check it closed the string and wnet back to normal mode properly.
+  AssertEqual 'terraComment', SyntaxOf('Comment')
+
+
+Given terraform (heredoc syntax);
+provisioner "local-exec" {
+  command = <<CMD
+echo ${aws_instance.web.private_ip} >> private_ips.txt && \
+my_command
+CMD # Comment
+
+  tags = {}
+  }
+}
+;
+
+Execute (syntax is good):
+  AssertEqual 'terraStringInterp', SyntaxOf('aws_instance')
+  AssertEqual 'terraHereDocText', SyntaxOf('my_command')
+
+  " Closing CMD is still here doc
+  AssertEqual 'terraHereDocText', SyntaxOf('CMD', 2)
+
+  " block should be closed
+  AssertEqual 'terraComment', SyntaxOf('Comment')
+
+  " tags should reset syntax
+  AssertEqual '', SyntaxOf("tags") 


### PR DESCRIPTION
This uses https://github.com/junegunn/vader.vim for the unit tests, and
the Travis config is based off
https://github.com/junegunn/seoul256.vim/blob/1475b7610663c68aa90b6e565997c8792ce0d222/.travis.yml
(linked from the vader.vim docs). I can't set up Travis for a repo I don't own
(can I?) so we'll have to see if this works there once it builds.

And to make it all easy to run locally include the relevant set up in a
Makefile. `make check` should run the tests.


Closes #42