### PR TITLE
Add AWS glue catalog database resource

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -396,6 +396,7 @@ syn keyword terraResourceTypeBI
           \ aws_emr_security_configuration
           \ aws_flow_log
           \ aws_glacier_vault
+          \ aws_glue_catalog_database
           \ aws_iam_access_key
           \ aws_iam_account_alias
           \ aws_iam_account_password_policy


### PR DESCRIPTION
The `aws_glue_catalog_database` resource was added in aws provider 1.7.