### PR TITLE
Don't require HEREDOC to end on blank line

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -1205,7 +1205,7 @@ syn match terraBraces        "[{}\[\]]"
 """ we may also want to pass \\" into a function to escape quotes.
 syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStringInterp
 syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction,terraValueVarSubscript,terraStringInterp contained
-syn region terraHereDocText   start=/<<\z([A-Z]\+\)/ end=/\z1/ contains=terraStringInterp
+syn region terraHereDocText   start=/<<-\?\z([A-Z]\+\)/ end=/^\s*\z1/ contains=terraStringInterp
 "" TODO match keywords here, not a-z+
 syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
 " User variables or module outputs can be lists or maps, and accessed with

--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -1205,7 +1205,7 @@ syn match terraBraces        "[{}\[\]]"
 """ we may also want to pass \\" into a function to escape quotes.
 syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStringInterp
 syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction,terraValueVarSubscript,terraStringInterp contained
-syn region terraHereDocText   start=/<<\z([A-Z]\+\)/ end=/^\z1/ contains=terraStringInterp
+syn region terraHereDocText   start=/<<\z([A-Z]\+\)/ end=/\z1/ contains=terraStringInterp
 "" TODO match keywords here, not a-z+
 syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
 " User variables or module outputs can be lists or maps, and accessed with


### PR DESCRIPTION
This is inconsistent with the syntax of terraform itself. The program doesn't require the HEREDOC end text to be at the start of the line, so the syntax highlighting should reflect that.

Without this change, syntax highlighting breaks with the following example (even though it's valid syntax):

```
resource FOOBAR {
  policy = <<POLICY
{
   <insert policy here>
}POLICY
}
```

Tested this locally with a file containing policy HEREDOCs in the above style and confirmed syntax highlighting works as expected.