### PR TITLE
add commentstring option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Allow vim-terraform to re-map the spacebar to fold/unfold. This works in conjunc
 
     let g:terraform_remap_spacebar=1
 
-If you use the [vim-commentary](https://github.com/tpope/vim-commentary) plugin, you should set the following option in your `~/.vimrc`. See [TOOLS-1](https://github.com/hashivim/vim-hashicorp-tools/pull/1) for more details.
+Override the Vim's `commentstring` setting with a custom value. Defaults to
+`#%s`. Example:
 
-    autocmd FileType terraform setlocal commentstring=#%s
+    let g:terraform_commentstring='//%s'
 
 - - - -
 # Updating vim-terraform

--- a/after/ftplugin/terraform.vim
+++ b/after/ftplugin/terraform.vim
@@ -72,3 +72,10 @@ if get(g:, "terraform_align", 1)
   setlocal softtabstop=2
   setlocal shiftwidth=2
 endif
+
+" Set the commentstring
+if exists('g:terraform_commentstring')
+    let &l:commentstring=g:terraform_commentstring
+else
+    setlocal commentstring=#%s
+endif


### PR DESCRIPTION
- override the Vim's default `/*%s*/` commentstring with `#%s`
- add new plugin option `g:terraform_commentstring` to customize it
- update the README.md