### PR TITLE
Align heredoc highlighting with hcl scanner syntax

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -1425,7 +1425,7 @@ syn match terraBraces        "[{}\[\]]"
 """ we may also want to pass \\" into a function to escape quotes.
 syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStringInterp
 syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction,terraValueVarSubscript,terraStringInterp contained
-syn region terraHereDocText   start=/<<\z([A-Z]\+\)/ end=/^\z1/ contains=terraStringInterp
+syn region terraHereDocText   start=/<<-\?\z([a-z0-9A-Z]\+\)/ end=/^\s*\z1/ contains=terraStringInterp
 "" TODO match keywords here, not a-z+
 syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
 " User variables or module outputs can be lists or maps, and accessed with


### PR DESCRIPTION
The [hcl library's scanner](https://github.com/hashicorp/hcl/blob/master/hcl/scanner/scanner.go#L393) allows heredoc labels to be prefixed with a hyphen to indicate that the contents are indented. Furthermore, it allows heredoc labels to include numerals and lowercase letters. Finally, hcl allows the terminal heredoc label to be indented.
Fixes #62