### PR TITLE
Include hyphens as keyword characters

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -5,6 +5,10 @@ if exists("b:current_syntax")
   finish
 endif
 
+" Include hyphens as keyword characters so that a keyword appearing as part of
+" a longer name doesn't get partially highlighted.
+setlocal iskeyword+=-
+
 syn case match
 
 syn keyword terraSection connection output provider variable data terraform locals


### PR DESCRIPTION
Terraform allows hyphens in identifiers. Consider the following template:

```
data "template_file" "storage-provisioner" {
  template = "${file("foo")}"
  vars {
    provisioner-name = "bar"
  }
}
```

Without this change, Vim will highlight the "provisioner" portion of "provisioner-name" as a keyword, different from the remaining "-name" portion.

A side effect is that navigating with "w" will no longer stop at a mid-word hyphen.