### PR TITLE
Change autocmd event from VimEnter to BufEnter

### DIFF
--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -59,9 +59,9 @@ endfunction
 
 augroup terraform
   autocmd!
-  autocmd VimEnter *
+  autocmd BufEnter *
         \ command! -nargs=+ -complete=custom,s:commands Terraform execute '!terraform '.<q-args>. ' -no-color'
-  autocmd VimEnter * command! -nargs=0 TerraformFmt call terraform#fmt()
+  autocmd BufEnter * command! -nargs=0 TerraformFmt call terraform#fmt()
   if get(g:, "terraform_fmt_on_save", 1)
     autocmd BufWritePre *.tf call terraform#fmt()
     autocmd BufWritePre *.tfvars call terraform#fmt()


### PR DESCRIPTION
This PR fixes the situation below:
1. open vim without argument(file)
2. open file with `:e main.tf`
3. couldn't load vim-terraform autocmd like `:TerraformFmt` command because on this time already `VimEnter`ed and no events match.