### PR TITLE
Prevent terraform fmt autosave from attempting to write to a target which isn't filereadable

### DIFF
--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -6,7 +6,7 @@ if exists("g:loaded_terraform") || v:version < 700 || &cp || !executable('terraf
 endif
 let g:loaded_terraform = 1
 
-if !exists("g:terraform_fmt_on_save")
+if !exists("g:terraform_fmt_on_save") || !filereadable(expand("%:p"))
   let g:terraform_fmt_on_save = 0
 endif
 


### PR DESCRIPTION
Fixes [this issue](https://github.com/tpope/vim-fugitive/issues/1128) related with vim-fugitive buffers from the vim-terraform side.