### PR TITLE
Add .tf extension to a temporary file for `terraform fmt`

### DIFF
--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -42,7 +42,7 @@ endfunction
 " https://github.com/fatih/vim-hclfmt/blob/master/autoload/fmt.vim
 function! terraform#fmt()
   let l:curw = winsaveview()
-  let l:tmpfile = tempname()
+  let l:tmpfile = tempname() . ".tf"
   call writefile(getline(1, "$"), l:tmpfile)
   let output = system("terraform fmt -write " . l:tmpfile)
   if v:shell_error == 0


### PR DESCRIPTION
Fixes: #84

Terraform v0.12-beta1 now checks file extensions for `terraform fmt`.
https://github.com/hashicorp/terraform/pull/20040

So we must specify the temporary file extension.