### PR TITLE
Add support for simple HCL2 / Terraform v0.12 syntax highlight

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -3387,6 +3387,10 @@ syn region terraProvisionerName start=/"/ end=/"/ nextgroup=terraProvisionerBloc
 syn match  terraModule     /\<module\>/ nextgroup=terraModuleName skipwhite
 syn region terraModuleName start=/"/ end=/"/ nextgroup=terraModuleBlock skipwhite
 
+""" dynamic (HCL2)
+syn match  terraDynamic     /\<dynamic\>/ nextgroup=terraDynamicName skipwhite
+syn region terraDynamicName start=/"/ end=/"/ nextgroup=terraDynamicBlock skipwhite
+
 """ misc.
 syn match terraValueDec      "\<[0-9]\+\([kKmMgG]b\?\)\?\>"
 syn match terraValueHexaDec  "\<0x[0-9a-f]\+\([kKmMgG]b\?\)\?\>"
@@ -3404,9 +3408,6 @@ syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ 
 syn region terraValueVarSubscript start=/\(\<var\|\<module\)\.[a-z0-9_-]\+\[/ end=/\]/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
 
 """ HCL2
-syn match  terraDynamic     /\<dynamic\>/ nextgroup=terraDynamicName skipwhite
-syn region terraDynamicName start=/"/ end=/"/ nextgroup=terraDynamicBlock skipwhite
-
 syn keyword terraContent        content
 syn keyword terraRepeat         for in
 syn keyword terraConditional    if

--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -3403,6 +3403,21 @@ syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ 
 " var.map["foo"]
 syn region terraValueVarSubscript start=/\(\<var\|\<module\)\.[a-z0-9_-]\+\[/ end=/\]/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
 
+""" HCL2
+syn match  terraDynamic     /\<dynamic\>/ nextgroup=terraDynamicName skipwhite
+syn region terraDynamicName start=/"/ end=/"/ nextgroup=terraDynamicBlock skipwhite
+
+syn keyword terraContent        content
+syn keyword terraRepeat         for in
+syn keyword terraConditional    if
+syn keyword terraPrimitiveType  string bool number
+syn keyword terraStructuralType object tuple
+syn keyword terraCollectionType list map set
+syn keyword terraValueNull      null
+
+""" Terraform v0.12
+syn keyword terraTodo contained TF-UPGRADE-TODO
+
 hi def link terraComment           Comment
 hi def link terraTodo              Todo
 hi def link terraBrackets          Operator
@@ -3430,5 +3445,14 @@ hi def link terraModule            Structure
 hi def link terraModuleName        String
 hi def link terraValueFunction     Identifier
 hi def link terraValueVarSubscript Identifier
+hi def link terraDynamic           Structure
+hi def link terraDynamicName       String
+hi def link terraContent           Structure
+hi def link terraRepeat            Repeat
+hi def link terraConditional       Conditional
+hi def link terraPrimitiveType     Type
+hi def link terraStructuralType    Type
+hi def link terraCollectionType    Type
+hi def link terraValueNull         Constant
 
 let b:current_syntax = "terraform"


### PR DESCRIPTION
Hi folks,

As you may know, Terraform v0.12, next major release, will introduce new configuration language HCL2.
It would be great if we could support HCL2 and Terraform v0.12.
https://www.hashicorp.com/blog/terraform-0-1-2-preview

I added simple HCL2 syntax highlight to my nvim, and I'm using it with Terraform v0.12-beta1.
I'm testing it with nvim v0.3.2.
![image](https://user-images.githubusercontent.com/6985802/54328487-6e663c80-4651-11e9-8fe5-02f4f37cf042.png)

I know that the current implementation is probably not perfect but not so bad.
So I will share this to all.
I believe this will give us a good start point for support HCL2 and Terraform v0.12.

The complete language specification of HCL2 is as follows:
https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md

Upgrade guide to Terraform v0.12 is here:
https://www.terraform.io/upgrade-guides/0-12.html

Note:
For now, it doesn't support for a new template interpolation syntax.
My vim skills is limited and too complicated to implement it properly :)
https://www.hashicorp.com/blog/terraform-0-12-template-syntax
 
Enjoy HCL2 and Terraform v0.12!
Thanks.