### PR TITLE
Simplify and improve indent

### DIFF
--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -30,24 +30,19 @@ function! TerraformIndent(lnum)
     return 0
   endif
 
-  " Previous non-blank line should continue the indent level
+  " Usual case is to continue at the same indent as the previous non-blank line.
   let prevlnum = prevnonblank(a:lnum-1)
+  let thisindent = indent(prevlnum)
 
-  " Previous line without comments should continue the indent level
-  let prevline = substitute(getline(prevlnum), '//.*$', '', '')
-  let previndent = indent(prevlnum)
-  let thisindent = previndent
-
-  " Config block starting with [ { ( should increase the indent level
-  if prevline =~# '[\[{\(]\s*$'
+  " If that previous line is a non-comment ending in [ { (, increase the
+  " indent level.
+  let prevline = getline(prevlnum)
+  if prevline !~# '^\s*\(#\|//\)' && prevline =~# '[\[{\(]\s*$'
     let thisindent += &shiftwidth
   endif
 
-  " Current line without comments should continue the indent level
-  let thisline = substitute(getline(a:lnum), '//.*$', '', '')
-
-  " Config block ending with ) } ] should get the indentation
-  " level from the initial config block
+  " If the current line ends a block, decrease the indent level.
+  let thisline = getline(a:lnum)
   if thisline =~# '^\s*[\)}\]]'
     let thisindent -= &shiftwidth
   endif


### PR DESCRIPTION
In particular, we now recognize lines beginning with '#' as comments.
Fixes #53.

(We can still be fooled by multiilne /* ... */ style comments.  Too
bad).