### PR TITLE
Enable folding with foldmethod=syntax

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -3728,7 +3728,7 @@ syn region terraDynamicName start=/"/ end=/"/ nextgroup=terraDynamicBlock skipwh
 """ misc.
 syn match terraValueDec      "\<[0-9]\+\([kKmMgG]b\?\)\?\>"
 syn match terraValueHexaDec  "\<0x[0-9a-f]\+\([kKmMgG]b\?\)\?\>"
-syn match terraBraces        "[{}\[\]]"
+syn match terraBraces        "[\[\]]"
 
 """ skip \" in strings.
 """ we may also want to pass \\" into a function to escape quotes.
@@ -3752,6 +3752,9 @@ syn keyword terraValueNull      null
 
 """ Terraform v0.12
 syn keyword terraTodo contained TF-UPGRADE-TODO
+
+" enable block folding
+syn region terraBlock matchgroup=terraBraces start="{" end="}" fold transparent
 
 hi def link terraComment           Comment
 hi def link terraTodo              Todo


### PR DESCRIPTION
As alternative approach to folding - more succinct than the `TerraformFolds()` and capable of folding inner blocks, but perhaps not really any better.

Still I think it makes sense for the syntax to understand this; after all no-one has to use `foldmethod=syntax` if they don't want to.