### PR TITLE
Remove g:terraform_commentstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,6 @@ Allow vim-terraform to re-map the spacebar to fold/unfold. This works in conjunc
 
     let g:terraform_remap_spacebar=1
 
-Override the Vim's `commentstring` setting with a custom value. Defaults to
-`#%s`. Example:
-
-    let g:terraform_commentstring='//%s'
-
 Allow vim-terraform to automatically format `*.tf` and `*.tfvars` files with `terraform fmt`.
 You can also do this manually with the `:TerraformFmt` command.
 

--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -30,7 +30,7 @@ if get(g:, 'terraform_fold_sections', 0)
 endif
 
 " Set the commentstring
-let &l:commentstring = get(g:, 'terraform_commentstring', '#%s')
+setlocal commentstring=#%s
 let b:undo_ftplugin .= ' commentstring<'
 
 " Re-map the space bar to fold and unfold


### PR DESCRIPTION
Just use the right value always

I expect this to be the least controversial part of the slimming program proposed in #94.

No rush to merge this - indeed we should probably leave it open for a little while so that users have at least some opportunity to notice and object.