### PR TITLE
Use syntax-based folding

### DIFF
--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -20,34 +20,6 @@ function! terraform#fmt()
   call winrestview(l:curw)
 endfunction
 
-function! terraform#folds()
-  let thisline = getline(v:lnum)
-  if match(thisline, '^resource') >= 0
-    return '>1'
-  elseif match(thisline, '^provider') >= 0
-    return '>1'
-  elseif match(thisline, '^module') >= 0
-    return '>1'
-  elseif match(thisline, '^variable') >= 0
-    return '>1'
-  elseif match(thisline, '^output') >= 0
-    return '>1'
-  elseif match(thisline, '^data') >= 0
-    return '>1'
-  elseif match(thisline, '^terraform') >= 0
-    return '>1'
-  elseif match(thisline, '^locals') >= 0
-    return '>1'
-  else
-    return '='
-  endif
-endfunction
-
-function! terraform#foldText()
-  let foldsize = (v:foldend-v:foldstart)
-  return getline(v:foldstart).' ('.foldsize.' lines)'
-endfunction
-
 function! terraform#align()
   let p = '^.*=[^>]*$'
   if exists(':Tabularize') && getline('.') =~# '^.*=' && (getline(line('.')-1) =~# p || getline(line('.')+1) =~# p)

--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -22,11 +22,8 @@ if !has('patch-7.4.1142')
 endif
 
 if get(g:, 'terraform_fold_sections', 0)
-  setlocal foldmethod=expr
-  setlocal foldexpr=terraform#folds()
-  setlocal foldlevel=1
-  setlocal foldtext=terraform#foldText()
-  let b:undo_ftplugin .= ' foldmethod< foldexpr< foldlevel< foldtext<'
+  setlocal foldmethod=syntax
+  let b:undo_ftplugin .= ' foldmethod<'
 endif
 
 " Set the commentstring


### PR DESCRIPTION
Another part of the general simplification proposed in #94.

Syntax-based folding does behave slightly differently than the expression-based folding that I'm removing here - though I think mostly better, as in it allows more folds (if you want them).  And the automatic fold expression is not quite the same as the one that we were previously providing.

However the simplification of the plugin - this pull request mostly just removes a pile of code - is IMO enough to justify such small changes.

As with the other pull requests in this series, no rush to merge - indeed it would probably be polite to leave this open for a short while so that users have a chance to notice and object.