### PR TITLE
Ran the updater against TF 0.12.8. Updated the list of resources, datasources, and providers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://img.shields.io/badge/Supports%20Terraform%20Version-%3E%3D0.12.6-blue.svg)](https://github.com/hashicorp/terraform/blob/v0.12.6/CHANGELOG.md)
+[![](https://img.shields.io/badge/Supports%20Terraform%20Version-%3E%3D0.12.8-blue.svg)](https://github.com/hashicorp/terraform/blob/v0.12.8/CHANGELOG.md)
 
 # Call For Maintainers
 

--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -107,6 +107,7 @@ syn keyword terraDataTypeBI
           \ alicloud_forward_entries
           \ alicloud_gpdb_instances
           \ alicloud_images
+          \ alicloud_instance_type_families
           \ alicloud_instance_types
           \ alicloud_instances
           \ alicloud_key_pairs
@@ -153,6 +154,7 @@ syn keyword terraDataTypeBI
           \ alicloud_slb_backend_servers
           \ alicloud_slb_ca_certificates
           \ alicloud_slb_listeners
+          \ alicloud_slb_master_slave_server_groups
           \ alicloud_slb_rules
           \ alicloud_slb_server_certificates
           \ alicloud_slb_server_groups
@@ -242,6 +244,9 @@ syn keyword terraDataTypeBI
           \ avi_wafpolicypsmgroup
           \ avi_wafprofile
           \ avi_webhook
+          \ aviatrix_account
+          \ aviatrix_caller_identity
+          \ aviatrix_gateway
           \ aws_acm_certificate
           \ aws_acmpca_certificate_authority
           \ aws_alb
@@ -305,6 +310,7 @@ syn keyword terraDataTypeBI
           \ aws_elastic_beanstalk_solution_stack
           \ aws_elasticache_cluster
           \ aws_elasticache_replication_group
+          \ aws_elasticsearch_domain
           \ aws_elb
           \ aws_elb_hosted_zone_id
           \ aws_elb_service_account
@@ -355,6 +361,8 @@ syn keyword terraDataTypeBI
           \ aws_region
           \ aws_route
           \ aws_route53_delegation_set
+          \ aws_route53_resolver_rule
+          \ aws_route53_resolver_rules
           \ aws_route53_zone
           \ aws_route_table
           \ aws_route_tables
@@ -439,6 +447,7 @@ syn keyword terraDataTypeBI
           \ azurerm_monitor_diagnostic_categories
           \ azurerm_monitor_log_profile
           \ azurerm_mssql_elasticpool
+          \ azurerm_network_ddos_protection_plan
           \ azurerm_network_interface
           \ azurerm_network_security_group
           \ azurerm_network_watcher
@@ -446,6 +455,7 @@ syn keyword terraDataTypeBI
           \ azurerm_notification_hub_namespace
           \ azurerm_platform_image
           \ azurerm_policy_definition
+          \ azurerm_proximity_placement_group
           \ azurerm_public_ip
           \ azurerm_public_ips
           \ azurerm_recovery_services_protection_policy_vm
@@ -456,12 +466,15 @@ syn keyword terraDataTypeBI
           \ azurerm_route_table
           \ azurerm_scheduler_job_collection
           \ azurerm_servicebus_namespace
+          \ azurerm_servicebus_namespace_authorization_rule
           \ azurerm_shared_image
           \ azurerm_shared_image_gallery
           \ azurerm_shared_image_version
           \ azurerm_snapshot
+          \ azurerm_sql_database
           \ azurerm_sql_server
           \ azurerm_storage_account
+          \ azurerm_storage_account_blob_container_sas
           \ azurerm_storage_account_sas
           \ azurerm_stream_analytics_job
           \ azurerm_subnet
@@ -530,6 +543,7 @@ syn keyword terraDataTypeBI
           \ dns_txt_record_set
           \ docker_network
           \ docker_registry_image
+          \ exoscale_compute_template
           \ external
           \ fastly_ip_ranges
           \ filter
@@ -593,6 +607,7 @@ syn keyword terraDataTypeBI
           \ google_compute_instance_group
           \ google_compute_lb_ip_ranges
           \ google_compute_network
+          \ google_compute_network_endpoint_group
           \ google_compute_node_types
           \ google_compute_region_instance_group
           \ google_compute_regions
@@ -614,6 +629,7 @@ syn keyword terraDataTypeBI
           \ google_kms_crypto_key_version
           \ google_kms_key_ring
           \ google_kms_secret
+          \ google_kms_secret_ciphertext
           \ google_netblock_ip_ranges
           \ google_organization
           \ google_project
@@ -631,6 +647,7 @@ syn keyword terraDataTypeBI
           \ grafana_data_source
           \ gridscale_ipv4
           \ gridscale_ipv6
+          \ gridscale_loadbalancer
           \ gridscale_network
           \ gridscale_sshkey
           \ gridscale_storage
@@ -716,6 +733,20 @@ syn keyword terraDataTypeBI
           \ logentries_logset
           \ logicmonitor_collectors
           \ logicmonitor_device_group
+          \ mongodbatlas_cloud_provider_snapshot
+          \ mongodbatlas_cloud_provider_snapshot_restore_job
+          \ mongodbatlas_cloud_provider_snapshot_restore_jobs
+          \ mongodbatlas_cloud_provider_snapshots
+          \ mongodbatlas_cluster
+          \ mongodbatlas_clusters
+          \ mongodbatlas_database_user
+          \ mongodbatlas_database_users
+          \ mongodbatlas_network_container
+          \ mongodbatlas_network_containers
+          \ mongodbatlas_network_peering
+          \ mongodbatlas_network_peerings
+          \ mongodbatlas_project
+          \ mongodbatlas_projects
           \ ncloud_access_control_group
           \ ncloud_access_control_groups
           \ ncloud_access_control_rule
@@ -791,6 +822,9 @@ syn keyword terraDataTypeBI
           \ oci_core_boot_volume_backup
           \ oci_core_boot_volume_backups
           \ oci_core_boot_volumes
+          \ oci_core_cluster_network
+          \ oci_core_cluster_network_instances
+          \ oci_core_cluster_networks
           \ oci_core_console_histories
           \ oci_core_console_history_data
           \ oci_core_cpes
@@ -801,6 +835,11 @@ syn keyword terraDataTypeBI
           \ oci_core_cross_connect_port_speed_shapes
           \ oci_core_cross_connect_status
           \ oci_core_cross_connects
+          \ oci_core_dedicated_vm_host
+          \ oci_core_dedicated_vm_host_instance_shapes
+          \ oci_core_dedicated_vm_host_shapes
+          \ oci_core_dedicated_vm_hosts
+          \ oci_core_dedicated_vm_hosts_instances
           \ oci_core_dhcp_options
           \ oci_core_drg_attachments
           \ oci_core_drgs
@@ -967,8 +1006,12 @@ syn keyword terraDataTypeBI
           \ oci_kms_keys
           \ oci_kms_vault
           \ oci_kms_vaults
+          \ oci_limits_limit_definitions
+          \ oci_limits_limit_values
           \ oci_limits_quota
           \ oci_limits_quotas
+          \ oci_limits_resource_availability
+          \ oci_limits_services
           \ oci_load_balancer_backend_health
           \ oci_load_balancer_backend_set_health
           \ oci_load_balancer_backend_sets
@@ -1007,9 +1050,14 @@ syn keyword terraDataTypeBI
           \ oci_ons_subscription
           \ oci_ons_subscriptions
           \ oci_streaming_stream
+          \ oci_streaming_stream_archiver
           \ oci_streaming_streams
+          \ oci_waas_address_list
+          \ oci_waas_address_lists
           \ oci_waas_certificate
           \ oci_waas_certificates
+          \ oci_waas_custom_protection_rule
+          \ oci_waas_custom_protection_rules
           \ oci_waas_edge_subnets
           \ oci_waas_waas_policies
           \ oci_waas_waas_policy
@@ -1037,8 +1085,11 @@ syn keyword terraDataTypeBI
           \ openstack_identity_group_v3
           \ openstack_identity_project_v3
           \ openstack_identity_role_v3
+          \ openstack_identity_service_v3
           \ openstack_identity_user_v3
           \ openstack_images_image_v2
+          \ openstack_keymanager_container_v1
+          \ openstack_keymanager_secret_v1
           \ openstack_networking_addressscope_v2
           \ openstack_networking_floatingip_v2
           \ openstack_networking_network_v2
@@ -1099,7 +1150,6 @@ syn keyword terraDataTypeBI
           \ opentelekomcloud_vpc_subnet_ids_v1
           \ opentelekomcloud_vpc_subnet_v1
           \ opentelekomcloud_vpc_v1
-          \ opsgenie_user
           \ oraclepaas_database_service_instance
           \ ovh_cloud_region
           \ ovh_cloud_regions
@@ -1128,7 +1178,9 @@ syn keyword terraDataTypeBI
           \ profitbricks_location
           \ profitbricks_resource
           \ profitbricks_snapshot
+          \ rancher2_app
           \ rancher2_catalog
+          \ rancher2_certificate
           \ rancher2_cloud_credential
           \ rancher2_cluster
           \ rancher2_cluster_driver
@@ -1136,13 +1188,17 @@ syn keyword terraDataTypeBI
           \ rancher2_cluster_role_template_binding
           \ rancher2_etcd_backup
           \ rancher2_global_role_binding
+          \ rancher2_multi_cluster_app
           \ rancher2_namespace
           \ rancher2_node_driver
           \ rancher2_node_pool
+          \ rancher2_node_template
           \ rancher2_project
           \ rancher2_project_logging
           \ rancher2_project_role_template_binding
           \ rancher2_registry
+          \ rancher2_role_template
+          \ rancher2_secret
           \ rancher2_setting
           \ rancher2_user
           \ rancher_certificate
@@ -1208,6 +1264,11 @@ syn keyword terraDataTypeBI
           \ tencentcloud_cbs_storages
           \ tencentcloud_ccn_bandwidth_limits
           \ tencentcloud_ccn_instances
+          \ tencentcloud_clb_attachments
+          \ tencentcloud_clb_instances
+          \ tencentcloud_clb_listener_rules
+          \ tencentcloud_clb_listeners
+          \ tencentcloud_clb_redirections
           \ tencentcloud_container_cluster_instances
           \ tencentcloud_container_clusters
           \ tencentcloud_cos_bucket_object
@@ -1216,21 +1277,34 @@ syn keyword terraDataTypeBI
           \ tencentcloud_dc_gateway_instances
           \ tencentcloud_dc_instances
           \ tencentcloud_dcx_instances
+          \ tencentcloud_dnats
           \ tencentcloud_eip
+          \ tencentcloud_gaap_certificates
+          \ tencentcloud_gaap_http_domains
+          \ tencentcloud_gaap_http_rules
+          \ tencentcloud_gaap_layer4_listeners
+          \ tencentcloud_gaap_layer7_listeners
+          \ tencentcloud_gaap_proxies
+          \ tencentcloud_gaap_realservers
+          \ tencentcloud_gaap_security_policies
+          \ tencentcloud_gaap_security_rules
           \ tencentcloud_image
           \ tencentcloud_instance_types
+          \ tencentcloud_kubernetes_clusters
           \ tencentcloud_mongodb_instances
           \ tencentcloud_mongodb_zone_config
           \ tencentcloud_mysql_backup_list
           \ tencentcloud_mysql_instance
           \ tencentcloud_mysql_parameter_list
           \ tencentcloud_mysql_zone_config
+          \ tencentcloud_nat_gateways
           \ tencentcloud_nats
           \ tencentcloud_redis_instances
           \ tencentcloud_redis_zone_config
           \ tencentcloud_route_table
           \ tencentcloud_security_group
           \ tencentcloud_security_groups
+          \ tencentcloud_ssl_certificates
           \ tencentcloud_subnet
           \ tencentcloud_vpc
           \ tencentcloud_vpc_instances
@@ -1289,6 +1363,8 @@ syn keyword terraDataTypeBI
           \ yandex_iam_role
           \ yandex_iam_service_account
           \ yandex_iam_user
+          \ yandex_lb_network_load_balancer
+          \ yandex_lb_target_group
           \ yandex_resourcemanager_cloud
           \ yandex_resourcemanager_folder
           \ yandex_vpc_network
@@ -1406,6 +1482,7 @@ syn keyword terraResourceTypeBI
           \ alicloud_ess_alarm
           \ alicloud_ess_attachment
           \ alicloud_ess_lifecycle_hook
+          \ alicloud_ess_notification
           \ alicloud_ess_scaling_configuration
           \ alicloud_ess_scaling_group
           \ alicloud_ess_scaling_rule
@@ -1486,6 +1563,7 @@ syn keyword terraResourceTypeBI
           \ alicloud_slb_backend_server
           \ alicloud_slb_ca_certificate
           \ alicloud_slb_listener
+          \ alicloud_slb_master_slave_server_group
           \ alicloud_slb_rule
           \ alicloud_slb_server_certificate
           \ alicloud_slb_server_group
@@ -1576,6 +1654,32 @@ syn keyword terraResourceTypeBI
           \ avi_wafpolicypsmgroup
           \ avi_wafprofile
           \ avi_webhook
+          \ aviatrix_account
+          \ aviatrix_account_user
+          \ aviatrix_arm_peer
+          \ aviatrix_aws_peer
+          \ aviatrix_aws_tgw
+          \ aviatrix_aws_tgw_vpc_attachment
+          \ aviatrix_aws_tgw_vpn_conn
+          \ aviatrix_controller_config
+          \ aviatrix_firewall
+          \ aviatrix_firewall_tag
+          \ aviatrix_fqdn
+          \ aviatrix_gateway
+          \ aviatrix_saml_endpoint
+          \ aviatrix_site2cloud
+          \ aviatrix_spoke_gateway
+          \ aviatrix_spoke_vpc
+          \ aviatrix_trans_peer
+          \ aviatrix_transit_gateway
+          \ aviatrix_transit_gateway_peering
+          \ aviatrix_transit_vpc
+          \ aviatrix_tunnel
+          \ aviatrix_vgw_conn
+          \ aviatrix_vpc
+          \ aviatrix_vpn_profile
+          \ aviatrix_vpn_user
+          \ aviatrix_vpn_user_accelerator
           \ aws_acm_certificate
           \ aws_acm_certificate_validation
           \ aws_acmpca_certificate_authority
@@ -1688,6 +1792,8 @@ syn keyword terraResourceTypeBI
           \ aws_config_configuration_recorder
           \ aws_config_configuration_recorder_status
           \ aws_config_delivery_channel
+          \ aws_config_organization_custom_rule
+          \ aws_config_organization_managed_rule
           \ aws_cur_report_definition
           \ aws_customer_gateway
           \ aws_datapipeline_pipeline
@@ -1742,6 +1848,7 @@ syn keyword terraResourceTypeBI
           \ aws_dx_lag
           \ aws_dx_private_virtual_interface
           \ aws_dx_public_virtual_interface
+          \ aws_dx_transit_virtual_interface
           \ aws_dynamodb_global_table
           \ aws_dynamodb_table
           \ aws_dynamodb_table_item
@@ -1793,6 +1900,8 @@ syn keyword terraResourceTypeBI
           \ aws_emr_security_configuration
           \ aws_flow_log
           \ aws_fms_admin_account
+          \ aws_fsx_lustre_file_system
+          \ aws_fsx_windows_file_system
           \ aws_gamelift_alias
           \ aws_gamelift_build
           \ aws_gamelift_fleet
@@ -1946,6 +2055,7 @@ syn keyword terraResourceTypeBI
           \ aws_ram_principal_association
           \ aws_ram_resource_association
           \ aws_ram_resource_share
+          \ aws_ram_resource_share_accepter
           \ aws_rds_cluster
           \ aws_rds_cluster_endpoint
           \ aws_rds_cluster_instance
@@ -1956,6 +2066,8 @@ syn keyword terraResourceTypeBI
           \ aws_redshift_parameter_group
           \ aws_redshift_security_group
           \ aws_redshift_snapshot_copy_grant
+          \ aws_redshift_snapshot_schedule
+          \ aws_redshift_snapshot_schedule_association
           \ aws_redshift_subnet_group
           \ aws_resourcegroups_group
           \ aws_route
@@ -2141,9 +2253,11 @@ syn keyword terraResourceTypeBI
           \ azurerm_api_management_user
           \ azurerm_app_service
           \ azurerm_app_service_active_slot
+          \ azurerm_app_service_certificate
           \ azurerm_app_service_custom_hostname_binding
           \ azurerm_app_service_plan
           \ azurerm_app_service_slot
+          \ azurerm_app_service_source_control_token
           \ azurerm_application_gateway
           \ azurerm_application_insights
           \ azurerm_application_insights_api_key
@@ -2169,17 +2283,21 @@ syn keyword terraResourceTypeBI
           \ azurerm_batch_application
           \ azurerm_batch_certificate
           \ azurerm_batch_pool
+          \ azurerm_bot_channels_registration
+          \ azurerm_bot_connection
           \ azurerm_cdn_endpoint
           \ azurerm_cdn_profile
           \ azurerm_cognitive_account
           \ azurerm_connection_monitor
           \ azurerm_container_group
           \ azurerm_container_registry
+          \ azurerm_container_registry_webhook
           \ azurerm_container_service
           \ azurerm_cosmosdb_account
           \ azurerm_cosmosdb_cassandra_keyspace
           \ azurerm_cosmosdb_mongo_collection
           \ azurerm_cosmosdb_mongo_database
+          \ azurerm_cosmosdb_sql_container
           \ azurerm_cosmosdb_sql_database
           \ azurerm_cosmosdb_table
           \ azurerm_data_factory
@@ -2230,6 +2348,7 @@ syn keyword terraResourceTypeBI
           \ azurerm_firewall_application_rule_collection
           \ azurerm_firewall_nat_rule_collection
           \ azurerm_firewall_network_rule_collection
+          \ azurerm_frontdoor
           \ azurerm_function_app
           \ azurerm_hdinsight_hadoop_cluster
           \ azurerm_hdinsight_hbase_cluster
@@ -2251,6 +2370,8 @@ syn keyword terraResourceTypeBI
           \ azurerm_key_vault_key
           \ azurerm_key_vault_secret
           \ azurerm_kubernetes_cluster
+          \ azurerm_kusto_cluster
+          \ azurerm_kusto_database
           \ azurerm_lb
           \ azurerm_lb_backend_address_pool
           \ azurerm_lb_nat_pool
@@ -2273,9 +2394,12 @@ syn keyword terraResourceTypeBI
           \ azurerm_management_group
           \ azurerm_management_lock
           \ azurerm_maps_account
+          \ azurerm_mariadb_configuration
           \ azurerm_mariadb_database
           \ azurerm_mariadb_firewall_rule
           \ azurerm_mariadb_server
+          \ azurerm_mariadb_virtual_network_rule
+          \ azurerm_marketplace_agreement
           \ azurerm_media_services_account
           \ azurerm_metric_alertrule
           \ azurerm_monitor_action_group
@@ -2316,11 +2440,20 @@ syn keyword terraResourceTypeBI
           \ azurerm_postgresql_server
           \ azurerm_postgresql_virtual_network_rule
           \ azurerm_private_dns_a_record
+          \ azurerm_private_dns_cname_record
           \ azurerm_private_dns_zone
+          \ azurerm_private_dns_zone_virtual_network_link
+          \ azurerm_proximity_placement_group
           \ azurerm_public_ip
           \ azurerm_public_ip_prefix
+          \ azurerm_recovery_network_mapping
+          \ azurerm_recovery_replicated_vm
+          \ azurerm_recovery_services_fabric
           \ azurerm_recovery_services_protected_vm
+          \ azurerm_recovery_services_protection_container
+          \ azurerm_recovery_services_protection_container_mapping
           \ azurerm_recovery_services_protection_policy_vm
+          \ azurerm_recovery_services_replication_policy
           \ azurerm_recovery_services_vault
           \ azurerm_redis_cache
           \ azurerm_redis_firewall_rule
@@ -2353,6 +2486,7 @@ syn keyword terraResourceTypeBI
           \ azurerm_sql_active_directory_administrator
           \ azurerm_sql_database
           \ azurerm_sql_elasticpool
+          \ azurerm_sql_failover_group
           \ azurerm_sql_firewall_rule
           \ azurerm_sql_server
           \ azurerm_sql_virtual_network_rule
@@ -2370,6 +2504,7 @@ syn keyword terraResourceTypeBI
           \ azurerm_stream_analytics_output_eventhub
           \ azurerm_stream_analytics_output_mssql
           \ azurerm_stream_analytics_output_servicebus_queue
+          \ azurerm_stream_analytics_output_servicebus_topic
           \ azurerm_stream_analytics_stream_input_blob
           \ azurerm_stream_analytics_stream_input_eventhub
           \ azurerm_stream_analytics_stream_input_iothub
@@ -2388,6 +2523,8 @@ syn keyword terraResourceTypeBI
           \ azurerm_virtual_network_gateway
           \ azurerm_virtual_network_gateway_connection
           \ azurerm_virtual_network_peering
+          \ azurerm_virtual_wan
+          \ azurerm_web_application_firewall_policy
           \ azurestack_availability_set
           \ azurestack_dns_a_record
           \ azurestack_dns_zone
@@ -2417,6 +2554,7 @@ syn keyword terraResourceTypeBI
           \ azurestack_virtual_network
           \ azurestack_virtual_network_gateway
           \ azurestack_virtual_network_gateway_connection
+          \ bigip_as3
           \ bigip_cm_device
           \ bigip_cm_devicegroup
           \ bigip_ltm_datagroup
@@ -2430,12 +2568,14 @@ syn keyword terraResourceTypeBI
           \ bigip_ltm_policy
           \ bigip_ltm_pool
           \ bigip_ltm_pool_attachment
+          \ bigip_ltm_profile_client_ssl
           \ bigip_ltm_profile_fasthttp
           \ bigip_ltm_profile_fastl4
           \ bigip_ltm_profile_http
           \ bigip_ltm_profile_http2
           \ bigip_ltm_profile_httpcompress
           \ bigip_ltm_profile_oneconnect
+          \ bigip_ltm_profile_server_ssl
           \ bigip_ltm_profile_tcp
           \ bigip_ltm_snat
           \ bigip_ltm_snatpool
@@ -2496,6 +2636,7 @@ syn keyword terraResourceTypeBI
           \ cloudflare_account_member
           \ cloudflare_argo
           \ cloudflare_custom_pages
+          \ cloudflare_custom_ssl
           \ cloudflare_filter
           \ cloudflare_firewall_rule
           \ cloudflare_load_balancer
@@ -2562,6 +2703,7 @@ syn keyword terraResourceTypeBI
           \ consul_prepared_query
           \ consul_service
           \ datadog_dashboard
+          \ datadog_dashboard_list
           \ datadog_downtime
           \ datadog_integration_aws
           \ datadog_integration_gcp
@@ -2570,6 +2712,7 @@ syn keyword terraResourceTypeBI
           \ datadog_metric_metadata
           \ datadog_monitor
           \ datadog_screenboard
+          \ datadog_service_level_objective
           \ datadog_synthetics_test
           \ datadog_timeboard
           \ datadog_user
@@ -2611,6 +2754,21 @@ syn keyword terraResourceTypeBI
           \ docker_service
           \ docker_volume
           \ dyn_record
+          \ exoscale_affinity
+          \ exoscale_compute
+          \ exoscale_domain
+          \ exoscale_domain_record
+          \ exoscale_ipaddress
+          \ exoscale_network
+          \ exoscale_nic
+          \ exoscale_secondary_ipaddress
+          \ exoscale_security_group
+          \ exoscale_security_group_rule
+          \ exoscale_security_group_rules
+          \ exoscale_ssh_keypair
+          \ fastly_service_acl_entries_v1
+          \ fastly_service_dictionary_items_v1
+          \ fastly_service_dynamic_snippet_content_v1
           \ fastly_service_v1
           \ flexibleengine_antiddos_v1
           \ flexibleengine_as_configuration_v1
@@ -2755,9 +2913,13 @@ syn keyword terraResourceTypeBI
           \ google_access_context_manager_access_policy
           \ google_access_context_manager_service_perimeter
           \ google_app_engine_application
+          \ google_app_engine_domain_mapping
           \ google_app_engine_firewall_rule
+          \ google_app_engine_standard_app_version
+          \ google_bigquery_data_transfer_config
           \ google_bigquery_dataset
           \ google_bigquery_table
+          \ google_bigtable_app_profile
           \ google_bigtable_instance
           \ google_bigtable_instance_iam_binding
           \ google_bigtable_instance_iam_member
@@ -2773,6 +2935,9 @@ syn keyword terraResourceTypeBI
           \ google_cloud_scheduler_job
           \ google_cloudbuild_trigger
           \ google_cloudfunctions_function
+          \ google_cloudfunctions_function_iam_binding
+          \ google_cloudfunctions_function_iam_member
+          \ google_cloudfunctions_function_iam_policy
           \ google_cloudiot_registry
           \ google_composer_environment
           \ google_compute_address
@@ -2845,6 +3010,7 @@ syn keyword terraResourceTypeBI
           \ google_container_cluster
           \ google_container_node_pool
           \ google_dataflow_job
+          \ google_dataproc_autoscaling_policy
           \ google_dataproc_cluster
           \ google_dataproc_cluster_iam_binding
           \ google_dataproc_cluster_iam_member
@@ -2883,6 +3049,18 @@ syn keyword terraResourceTypeBI
           \ google_iap_tunnel_instance_iam_binding
           \ google_iap_tunnel_instance_iam_member
           \ google_iap_tunnel_instance_iam_policy
+          \ google_iap_web_backend_service_iam_binding
+          \ google_iap_web_backend_service_iam_member
+          \ google_iap_web_backend_service_iam_policy
+          \ google_iap_web_iam_binding
+          \ google_iap_web_iam_member
+          \ google_iap_web_iam_policy
+          \ google_iap_web_type_app_engine_iam_binding
+          \ google_iap_web_type_app_engine_iam_member
+          \ google_iap_web_type_app_engine_iam_policy
+          \ google_iap_web_type_compute_iam_binding
+          \ google_iap_web_type_compute_iam_member
+          \ google_iap_web_type_compute_iam_policy
           \ google_kms_crypto_key
           \ google_kms_crypto_key_iam_binding
           \ google_kms_crypto_key_iam_member
@@ -2899,6 +3077,7 @@ syn keyword terraResourceTypeBI
           \ google_logging_organization_sink
           \ google_logging_project_exclusion
           \ google_logging_project_sink
+          \ google_ml_engine_model
           \ google_monitoring_alert_policy
           \ google_monitoring_group
           \ google_monitoring_notification_channel
@@ -2930,6 +3109,7 @@ syn keyword terraResourceTypeBI
           \ google_resource_manager_lien
           \ google_runtimeconfig_config
           \ google_runtimeconfig_variable
+          \ google_scc_source
           \ google_security_scanner_scan_config
           \ google_service_account
           \ google_service_account_iam_binding
@@ -2966,6 +3146,7 @@ syn keyword terraResourceTypeBI
           \ google_storage_object_acl
           \ google_storage_transfer_job
           \ google_tpu_node
+          \ google_vpc_access_connector
           \ grafana_alert_notification
           \ grafana_dashboard
           \ grafana_data_source
@@ -2973,6 +3154,7 @@ syn keyword terraResourceTypeBI
           \ grafana_organization
           \ gridscale_ipv4
           \ gridscale_ipv6
+          \ gridscale_loadbalancer
           \ gridscale_network
           \ gridscale_server
           \ gridscale_sshkey
@@ -3029,6 +3211,7 @@ syn keyword terraResourceTypeBI
           \ huaweicloud_compute_floatingip_associate_v2
           \ huaweicloud_compute_floatingip_v2
           \ huaweicloud_compute_instance_v2
+          \ huaweicloud_compute_interface_attach_v2
           \ huaweicloud_compute_keypair_v2
           \ huaweicloud_compute_secgroup_v2
           \ huaweicloud_compute_servergroup_v2
@@ -3046,9 +3229,11 @@ syn keyword terraResourceTypeBI
           \ huaweicloud_dms_group_v1
           \ huaweicloud_dms_instance_v1
           \ huaweicloud_dms_queue_v1
+          \ huaweicloud_dns_ptrrecord_v2
           \ huaweicloud_dns_recordset_v2
           \ huaweicloud_dns_zone_v2
           \ huaweicloud_dws_cluster
+          \ huaweicloud_ecs_instance_v1
           \ huaweicloud_elb_backendecs
           \ huaweicloud_elb_healthcheck
           \ huaweicloud_elb_listener
@@ -3100,6 +3285,7 @@ syn keyword terraResourceTypeBI
           \ huaweicloud_smn_topic_v2
           \ huaweicloud_vbs_backup_policy_v2
           \ huaweicloud_vbs_backup_v2
+          \ huaweicloud_vpc_bandwidth_v2
           \ huaweicloud_vpc_eip_v1
           \ huaweicloud_vpc_peering_connection_accepter_v2
           \ huaweicloud_vpc_peering_connection_v2
@@ -3145,6 +3331,7 @@ syn keyword terraResourceTypeBI
           \ jdcloud_route_table_rules
           \ jdcloud_subnet
           \ jdcloud_vpc
+          \ kubernetes_api_service
           \ kubernetes_cluster_role
           \ kubernetes_cluster_role_binding
           \ kubernetes_config_map
@@ -3195,6 +3382,15 @@ syn keyword terraResourceTypeBI
           \ logicmonitor_device
           \ logicmonitor_device_group
           \ mailgun_domain
+          \ mongodbatlas_cloud_provider_snapshot
+          \ mongodbatlas_cloud_provider_snapshot_restore_job
+          \ mongodbatlas_cluster
+          \ mongodbatlas_database_user
+          \ mongodbatlas_encryption_at_rest
+          \ mongodbatlas_network_container
+          \ mongodbatlas_network_peering
+          \ mongodbatlas_project
+          \ mongodbatlas_project_ip_whitelist
           \ mysql_database
           \ mysql_grant
           \ mysql_role
@@ -3315,10 +3511,12 @@ syn keyword terraResourceTypeBI
           \ oci_core_app_catalog_subscription
           \ oci_core_boot_volume
           \ oci_core_boot_volume_backup
+          \ oci_core_cluster_network
           \ oci_core_console_history
           \ oci_core_cpe
           \ oci_core_cross_connect
           \ oci_core_cross_connect_group
+          \ oci_core_dedicated_vm_host
           \ oci_core_default_dhcp_options
           \ oci_core_default_route_table
           \ oci_core_default_security_list
@@ -3413,6 +3611,7 @@ syn keyword terraResourceTypeBI
           \ oci_kms_key_version
           \ oci_kms_vault
           \ oci_limits_quota
+          \ oci_limits_resource_availability
           \ oci_load_balancer
           \ oci_load_balancer_backend
           \ oci_load_balancer_backend_set
@@ -3432,7 +3631,11 @@ syn keyword terraResourceTypeBI
           \ oci_ons_notification_topic
           \ oci_ons_subscription
           \ oci_streaming_stream
+          \ oci_streaming_stream_archiver
+          \ oci_waas_address_list
           \ oci_waas_certificate
+          \ oci_waas_custom_protection_rule
+          \ oci_waas_purge_cache
           \ oci_waas_waas_policy
           \ oneandone_baremetal
           \ oneandone_block_storage
@@ -3481,6 +3684,8 @@ syn keyword terraResourceTypeBI
           \ opc_lbaas_server_pool
           \ opc_storage_container
           \ opc_storage_object
+          \ openstack_blockstorage_quotaset_v2
+          \ openstack_blockstorage_quotaset_v3
           \ openstack_blockstorage_volume_attach_v2
           \ openstack_blockstorage_volume_attach_v3
           \ openstack_blockstorage_volume_v1
@@ -3508,9 +3713,11 @@ syn keyword terraResourceTypeBI
           \ openstack_fw_policy_v1
           \ openstack_fw_rule_v1
           \ openstack_identity_application_credential_v3
+          \ openstack_identity_endpoint_v3
           \ openstack_identity_project_v3
           \ openstack_identity_role_assignment_v3
           \ openstack_identity_role_v3
+          \ openstack_identity_service_v3
           \ openstack_identity_user_v3
           \ openstack_images_image_v2
           \ openstack_keymanager_container_v1
@@ -3536,6 +3743,7 @@ syn keyword terraResourceTypeBI
           \ openstack_networking_qos_dscp_marking_rule_v2
           \ openstack_networking_qos_minimum_bandwidth_rule_v2
           \ openstack_networking_qos_policy_v2
+          \ openstack_networking_rbac_policy_v2
           \ openstack_networking_router_interface_v2
           \ openstack_networking_router_route_v2
           \ openstack_networking_router_v2
@@ -3584,6 +3792,7 @@ syn keyword terraResourceTypeBI
           \ opentelekomcloud_dms_queue_v1
           \ opentelekomcloud_dns_recordset_v2
           \ opentelekomcloud_dns_zone_v2
+          \ opentelekomcloud_ecs_instance_v1
           \ opentelekomcloud_elb_backend
           \ opentelekomcloud_elb_health
           \ opentelekomcloud_elb_listener
@@ -3654,8 +3863,16 @@ syn keyword terraResourceTypeBI
           \ opentelekomcloud_waf_preciseprotection_rule_v1
           \ opentelekomcloud_waf_webtamperprotection_rule_v1
           \ opentelekomcloud_waf_whiteblackip_rule_v1
+          \ opsgenie_api_integration
+          \ opsgenie_email_integration
+          \ opsgenie_escalation
+          \ opsgenie_heartbeat
+          \ opsgenie_maintenance
+          \ opsgenie_schedule
+          \ opsgenie_schedule_rotation
           \ opsgenie_team
           \ opsgenie_user
+          \ opsgenie_user_contact
           \ oraclepaas_application_container
           \ oraclepaas_database_access_rule
           \ oraclepaas_database_service_instance
@@ -3696,6 +3913,7 @@ syn keyword terraResourceTypeBI
           \ packet_volume_attachment
           \ pagerduty_addon
           \ pagerduty_escalation_policy
+          \ pagerduty_event_rule
           \ pagerduty_extension
           \ pagerduty_maintenance_window
           \ pagerduty_schedule
@@ -3709,6 +3927,9 @@ syn keyword terraResourceTypeBI
           \ panos_address_object
           \ panos_administrative_tag
           \ panos_aggregate_interface
+          \ panos_application_group
+          \ panos_application_object
+          \ panos_application_signature
           \ panos_bfd_profile
           \ panos_bgp
           \ panos_bgp_aggregate
@@ -3726,9 +3947,11 @@ syn keyword terraResourceTypeBI
           \ panos_bgp_redist_rule
           \ panos_dag_tags
           \ panos_edl
+          \ panos_email_server_profile
           \ panos_ethernet_interface
           \ panos_general_settings
           \ panos_gre_tunnel
+          \ panos_http_server_profile
           \ panos_ike_crypto_profile
           \ panos_ike_gateway
           \ panos_ipsec_crypto_profile
@@ -3738,6 +3961,7 @@ syn keyword terraResourceTypeBI
           \ panos_layer3_subinterface
           \ panos_license_api_key
           \ panos_licensing
+          \ panos_log_forwarding_profile
           \ panos_loopback_interface
           \ panos_management_profile
           \ panos_monitor_profile
@@ -3748,6 +3972,9 @@ syn keyword terraResourceTypeBI
           \ panos_panorama_address_object
           \ panos_panorama_administrative_tag
           \ panos_panorama_aggregate_interface
+          \ panos_panorama_application_group
+          \ panos_panorama_application_object
+          \ panos_panorama_application_signature
           \ panos_panorama_bfd_profile
           \ panos_panorama_bgp
           \ panos_panorama_bgp_aggregate
@@ -3766,11 +3993,13 @@ syn keyword terraResourceTypeBI
           \ panos_panorama_device_group
           \ panos_panorama_device_group_entry
           \ panos_panorama_edl
+          \ panos_panorama_email_server_profile
           \ panos_panorama_ethernet_interface
           \ panos_panorama_gcp_account
           \ panos_panorama_gke_cluster
           \ panos_panorama_gke_cluster_group
           \ panos_panorama_gre_tunnel
+          \ panos_panorama_http_server_profile
           \ panos_panorama_ike_crypto_profile
           \ panos_panorama_ike_gateway
           \ panos_panorama_ipsec_crypto_profile
@@ -3778,6 +4007,7 @@ syn keyword terraResourceTypeBI
           \ panos_panorama_ipsec_tunnel_proxy_id_ipv4
           \ panos_panorama_layer2_subinterface
           \ panos_panorama_layer3_subinterface
+          \ panos_panorama_log_forwarding_profile
           \ panos_panorama_loopback_interface
           \ panos_panorama_management_profile
           \ panos_panorama_monitor_profile
@@ -3792,7 +4022,9 @@ syn keyword terraResourceTypeBI
           \ panos_panorama_security_rule_group
           \ panos_panorama_service_group
           \ panos_panorama_service_object
+          \ panos_panorama_snmptrap_server_profile
           \ panos_panorama_static_route_ipv4
+          \ panos_panorama_syslog_server_profile
           \ panos_panorama_template
           \ panos_panorama_template_entry
           \ panos_panorama_template_stack
@@ -3814,7 +4046,9 @@ syn keyword terraResourceTypeBI
           \ panos_security_rule_group
           \ panos_service_group
           \ panos_service_object
+          \ panos_snmptrap_server_profile
           \ panos_static_route_ipv4
+          \ panos_syslog_server_profile
           \ panos_telemetry
           \ panos_tunnel_interface
           \ panos_virtual_router
@@ -3853,6 +4087,7 @@ syn keyword terraResourceTypeBI
           \ rabbitmq_queue
           \ rabbitmq_user
           \ rabbitmq_vhost
+          \ rancher2_app
           \ rancher2_auth_config_activedirectory
           \ rancher2_auth_config_adfs
           \ rancher2_auth_config_azuread
@@ -3862,6 +4097,7 @@ syn keyword terraResourceTypeBI
           \ rancher2_auth_config_ping
           \ rancher2_bootstrap
           \ rancher2_catalog
+          \ rancher2_certificate
           \ rancher2_cloud_credential
           \ rancher2_cluster
           \ rancher2_cluster_driver
@@ -3869,6 +4105,7 @@ syn keyword terraResourceTypeBI
           \ rancher2_cluster_role_template_binding
           \ rancher2_etcd_backup
           \ rancher2_global_role_binding
+          \ rancher2_multi_cluster_app
           \ rancher2_namespace
           \ rancher2_node_driver
           \ rancher2_node_pool
@@ -3877,6 +4114,8 @@ syn keyword terraResourceTypeBI
           \ rancher2_project_logging
           \ rancher2_project_role_template_binding
           \ rancher2_registry
+          \ rancher2_role_template
+          \ rancher2_secret
           \ rancher2_setting
           \ rancher2_user
           \ rancher_certificate
@@ -3920,19 +4159,21 @@ syn keyword terraResourceTypeBI
           \ runscope_schedule
           \ runscope_step
           \ runscope_test
+          \ scaleway_account_ssh_key
+          \ scaleway_baremetal_server_beta
           \ scaleway_bucket
-          \ scaleway_compute_instance_ip
-          \ scaleway_compute_instance_placement_group
-          \ scaleway_compute_instance_security_group
-          \ scaleway_compute_instance_server
-          \ scaleway_compute_instance_volume
+          \ scaleway_instance_ip
+          \ scaleway_instance_placement_group
+          \ scaleway_instance_security_group
+          \ scaleway_instance_server
+          \ scaleway_instance_volume
           \ scaleway_ip
           \ scaleway_ip_reverse_dns
+          \ scaleway_object_bucket
           \ scaleway_security_group
           \ scaleway_security_group_rule
           \ scaleway_server
           \ scaleway_ssh_key
-          \ scaleway_storage_object_bucket
           \ scaleway_token
           \ scaleway_user_data
           \ scaleway_volume
@@ -3955,8 +4196,9 @@ syn keyword terraResourceTypeBI
           \ signalfx_event_feed_chart
           \ signalfx_gcp_integration
           \ signalfx_heatmap_chart
-          \ signalfx_integration
           \ signalfx_list_chart
+          \ signalfx_opsgenie_integration
+          \ signalfx_org_token
           \ signalfx_pagerduty_integration
           \ signalfx_single_value_chart
           \ signalfx_slack_integration
@@ -4043,6 +4285,11 @@ syn keyword terraResourceTypeBI
           \ tencentcloud_ccn
           \ tencentcloud_ccn_attachment
           \ tencentcloud_ccn_bandwidth_limit
+          \ tencentcloud_clb_attachment
+          \ tencentcloud_clb_instance
+          \ tencentcloud_clb_listener
+          \ tencentcloud_clb_listener_rule
+          \ tencentcloud_clb_redirection
           \ tencentcloud_container_cluster
           \ tencentcloud_container_cluster_instance
           \ tencentcloud_cos_bucket
@@ -4053,8 +4300,19 @@ syn keyword terraResourceTypeBI
           \ tencentcloud_dnat
           \ tencentcloud_eip
           \ tencentcloud_eip_association
+          \ tencentcloud_gaap_certificate
+          \ tencentcloud_gaap_http_domain
+          \ tencentcloud_gaap_http_rule
+          \ tencentcloud_gaap_layer4_listener
+          \ tencentcloud_gaap_layer7_listener
+          \ tencentcloud_gaap_proxy
+          \ tencentcloud_gaap_realserver
+          \ tencentcloud_gaap_security_policy
+          \ tencentcloud_gaap_security_rule
           \ tencentcloud_instance
           \ tencentcloud_key_pair
+          \ tencentcloud_kubernetes_cluster
+          \ tencentcloud_kubernetes_scale_worker
           \ tencentcloud_lb
           \ tencentcloud_mongodb_instance
           \ tencentcloud_mongodb_sharding_instance
@@ -4071,8 +4329,10 @@ syn keyword terraResourceTypeBI
           \ tencentcloud_route_table_entry
           \ tencentcloud_security_group
           \ tencentcloud_security_group_rule
+          \ tencentcloud_ssl_certificate
           \ tencentcloud_subnet
           \ tencentcloud_vpc
+          \ tfe_notification_configuration
           \ tfe_oauth_client
           \ tfe_organization
           \ tfe_organization_token
@@ -4167,6 +4427,8 @@ syn keyword terraResourceTypeBI
           \ yandex_iam_service_account_iam_member
           \ yandex_iam_service_account_iam_policy
           \ yandex_iam_service_account_static_access_key
+          \ yandex_lb_network_load_balancer
+          \ yandex_lb_target_group
           \ yandex_resourcemanager_cloud
           \ yandex_resourcemanager_cloud_iam_binding
           \ yandex_resourcemanager_cloud_iam_member

--- a/update_automagic.sh
+++ b/update_automagic.sh
@@ -15,22 +15,16 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-EXISTING_TF_VERSION=$(terraform version | head -n1 | sed -e 's/Terraform//gI' -e 's/v//gI' -e 's/[[:space:]]//g')
-
-if [ "${EXISTING_TF_VERSION}" != "${VERSION}" ]; then
-    echo "-) You are trying to update this script for terraform ${VERSION} while you have"
-    echo "   terraform ${EXISTING_TF_VERSION} installed at $(which terraform)."
-    echo "   Please update your local terraform before using this script."
-    exit 1
-fi
+PLATFORM="$(uname | tr [A-Z] [a-z])"
 
 echo "+) Acquiring terraform-${VERSION}"
-if [ ! -f "v${VERSION}.tar.gz" ]; then
-    wget https://github.com/hashicorp/terraform/archive/v${VERSION}.tar.gz
+if [ ! -f "terraform_${VERSION}_${PLATFORM}_amd64.zip" ]; then
+    curl -O https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_${PLATFORM}_amd64.zip
 fi
 
 echo "+) Extracting terraform-${VERSION}.tar.gz"
-tar zxf v${VERSION}.tar.gz
+rm -f terraform
+unzip terraform_${VERSION}_${PLATFORM}_amd64.zip
 
 echo "+) Getting providers"
 ./get_providers.sh
@@ -48,7 +42,8 @@ echo "+) Updating the badge in the README.md"
 sed -i "/img.shields.io/c\[\![](https://img.shields.io/badge/Supports%20Terraform%20Version-%3E%3D${VERSION}-blue.svg)](https://github.com/hashicorp/terraform/blob/v${VERSION}/CHANGELOG.md)" README.md
 
 echo "+) Cleaning up after ourselves"
-rm -f v${VERSION}.tar.gz
+rm -f terraform_${VERSION}_${PLATFORM}_amd64.zip
+rm -f terraform
 rm -rf terraform-${VERSION}
 sudo umount terraform-providers
 

--- a/update_commands.rb
+++ b/update_commands.rb
@@ -11,10 +11,8 @@ plugin_file = 'autoload/terraform.vim'
 
 if File.file?('./terraform')
     stdout, stderr, _status = Open3.capture3('./terraform list-commands')
-    print 'local TF found'
 else
     stdout, stderr, _status = Open3.capture3('terraform list-commands')
-    print 'local TF not found'
 end
 
 output = if stderr == ''

--- a/update_commands.rb
+++ b/update_commands.rb
@@ -8,7 +8,15 @@ command_re = /^\s\s\s\s(\S+)/
 plugin_file = 'autoload/terraform.vim'
 
 # Create the list of commands.
-stdout, stderr, _status = Open3.capture3('terraform list-commands')
+
+if File.file?('./terraform')
+    stdout, stderr, _status = Open3.capture3('./terraform list-commands')
+    print 'local TF found'
+else
+    stdout, stderr, _status = Open3.capture3('terraform list-commands')
+    print 'local TF not found'
+end
+
 output = if stderr == ''
            stdout.split("\n")
          else


### PR DESCRIPTION
`update_automagic.sh` no longer needs you to have the most up to date terraform on your PATH.
`update_commands.rb` now searchs for a local terraform before searching the PATH.