### PR TITLE
Fix #114: fmt error if TF_CLI_ARGS* in env

### DIFF
--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -6,7 +6,7 @@ function! terraform#fmt()
   " Make a fake change so that the undo point is right.
   normal! ix
   normal! "_x
-  silent execute '%!terraform fmt -no-color -'
+  silent execute '%!TF_CLI_ARGS_fmt= terraform fmt -no-color -'
   if v:shell_error != 0
     let output = getline(1, '$')
     silent undo

--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -1,3 +1,6 @@
+" Ensure no conflict with arguments from the environment
+let $TF_CLI_ARGS_fmt=''
+
 function! terraform#fmt()
   if !filereadable(expand('%:p'))
     return
@@ -6,7 +9,6 @@ function! terraform#fmt()
   " Make a fake change so that the undo point is right.
   normal! ix
   normal! "_x
-  let $TF_CLI_ARGS_fmt=''
   silent execute '%!terraform fmt -no-color -'
   if v:shell_error != 0
     let output = getline(1, '$')

--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -6,7 +6,8 @@ function! terraform#fmt()
   " Make a fake change so that the undo point is right.
   normal! ix
   normal! "_x
-  silent execute '%!TF_CLI_ARGS_fmt= terraform fmt -no-color -'
+  let $TF_CLI_ARGS_fmt=''
+  silent execute '%!terraform fmt -no-color -'
   if v:shell_error != 0
     let output = getline(1, '$')
     silent undo


### PR DESCRIPTION
If TF_CLI_ARGS or TF_CLI_ARGS_fmt env vars are used formatting may fail with invalid args. For example, `TF_CLI_ARGS_fmt=<tf_dir>` may be desirable for running outside of vim, but when vim-terraform adds thcalls `terraform fmt <tf_dir>` will cause it to fail due to twice listing the directory when only a single argument is expected.

This commit addresses the issue by ensuring no args come from the environment when vim-terraform calls fmt.