### PR TITLE
Fix autocompletion for partial Terraform arguments

### DIFF
--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -29,31 +29,32 @@ function! terraform#align()
   endif
 endfunction
 
-function! terraform#commands(A, L, P)
-  return [
-  \ 'apply',
-  \ 'console',
-  \ 'destroy',
-  \ 'env',
-  \ 'fmt',
-  \ 'get',
-  \ 'graph',
-  \ 'import',
-  \ 'init',
-  \ 'output',
-  \ 'plan',
-  \ 'providers',
-  \ 'refresh',
-  \ 'show',
-  \ 'taint',
-  \ 'untaint',
-  \ 'validate',
-  \ 'version',
-  \ 'workspace',
-  \ '0.12upgrade',
-  \ 'debug',
-  \ 'force-unlock',
-  \ 'push',
-  \ 'state'
+function! terraform#commands(ArgLead, CmdLine, CursorPos)
+  let l:commands = [
+    \ 'apply',
+    \ 'console',
+    \ 'destroy',
+    \ 'env',
+    \ 'fmt',
+    \ 'get',
+    \ 'graph',
+    \ 'import',
+    \ 'init',
+    \ 'output',
+    \ 'plan',
+    \ 'providers',
+    \ 'refresh',
+    \ 'show',
+    \ 'taint',
+    \ 'untaint',
+    \ 'validate',
+    \ 'version',
+    \ 'workspace',
+    \ '0.12upgrade',
+    \ 'debug',
+    \ 'force-unlock',
+    \ 'push',
+    \ 'state'
   \ ]
+  return join(l:commands, "\n")
 endfunction

--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -45,7 +45,7 @@ endif
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-command! -nargs=+ -complete=customlist,terraform#commands -buffer Terraform execute '!terraform '.<q-args>. ' -no-color'
+command! -nargs=+ -complete=custom,terraform#commands -buffer Terraform execute '!terraform '.<q-args>. ' -no-color'
 command! -nargs=0 -buffer TerraformFmt call terraform#fmt()
 let b:undo_ftplugin .= '|delcommand Terraform|delcommand TerraformFmt'
 

--- a/update_commands.rb
+++ b/update_commands.rb
@@ -22,14 +22,14 @@ output = if stderr == ''
          end
 commands = output.collect do |l|
   match = command_re.match(l)
-  "  \\ '#{match[1]}'" if match
+  "    \\ '#{match[1]}'" if match
 end.reject(&:nil?).join(",\n")
 
 # Read in the existing plugin file.
 plugin = File.open(plugin_file, 'r').readlines
 
 # Replace the terraResourceTypeBI lines with our new list.
-first = plugin.index { |l| /^  return \[/.match(l) } + 1
+first = plugin.index { |l| /^  let l:commands = \[/.match(l) } + 1
 last = plugin.index { |l| /^  \\ \]\n/.match(l) }
 plugin.slice!(first, last - first)
 commands.split("\n").reverse_each do |r|


### PR DESCRIPTION
Broken by the switch to using `customlist` for completion.  Change back!