### PR TITLE
Remove data from keywords

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -13,7 +13,7 @@ endif
 
 syn case match
 
-syn keyword terraSection connection output provider variable data terraform locals
+syn keyword terraSection connection output provider variable terraform locals
 syn keyword terraValueBool true false on off yes no
 
 """ data


### PR DESCRIPTION
Otherwise, the string following the `data` keyword (the data type) gets
highlighted as a string rather than as a `terraDataTypeBI`

Before:

![before](https://user-images.githubusercontent.com/107804/68094397-92d38b00-fe65-11e9-8f9c-e15950c56349.png)

After:

![after](https://user-images.githubusercontent.com/107804/68094402-9ebf4d00-fe65-11e9-8357-b998d393f3a3.png)
