### PR TITLE
Adding contains to terrablock to highlight functions inside blocks

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -4868,7 +4868,7 @@ syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStrin
 syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction,terraValueVarSubscript,terraStringInterp contained
 syn region terraHereDocText   start=/<<-\?\z([a-z0-9A-Z]\+\)/ end=/^\s*\z1/ contains=terraStringInterp
 "" TODO match keywords here, not a-z+
-syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
+syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction,terraValueVarSubscript,terraBlock contained
 " User variables or module outputs can be lists or maps, and accessed with
 " var.map["foo"]
 syn region terraValueVarSubscript start=/\(\<var\|\<module\)\.[a-z0-9_-]\+\[/ end=/\]/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
@@ -4886,7 +4886,7 @@ syn keyword terraValueNull      null
 syn keyword terraTodo contained TF-UPGRADE-TODO
 
 " enable block folding
-syn region terraBlock matchgroup=terraBraces start="{" end="}" fold transparent
+syn region terraBlock matchgroup=terraBraces start="{" end="}" contains=terraComment,terraHereDocText,terraValueString,terraValueFunction,terraValueVarSubscript,terraStringInterp fold transparent 
 
 hi def link terraComment           Comment
 hi def link terraTodo              Todo
@@ -4926,3 +4926,4 @@ hi def link terraCollectionType    Type
 hi def link terraValueNull         Constant
 
 let b:current_syntax = 'terraform'
+


### PR DESCRIPTION
This PR was something I worked on for a few hours last night due to my lack of experience with vim syntax and optimizations. Ultimately, I noticed that certain terraform functions for example were not highlighted inside blocks:

![image](https://user-images.githubusercontent.com/12246915/69363150-8e74e380-0c55-11ea-8e6d-dea4523695e7.png)

So, first i added all the region marked as "contained" to the terraBlock region. This gave me this:
![image](https://user-images.githubusercontent.com/12246915/69363279-dac02380-0c55-11ea-9617-5dd63b1328bc.png)

I noticed that the {}s were colored red, so then I added the terraBlock as a contains member of terraValueFunction, which gave me this:
![image](https://user-images.githubusercontent.com/12246915/69363410-1a870b00-0c56-11ea-8316-5ee90c09a54e.png)

Which is ultimately what I wanted and it mostly matched what VSCode would show for this file using the same colortheme. There is probably still room to add syntax highlighting for literal expression such as maps. If you notice in the last screenshot, the literal expression, the key in the map is colored red and in other places its not, a way to get more consistency is needed. If you can point me in the right direction, I can take a look at it.
![image](https://user-images.githubusercontent.com/12246915/69364315-bd8c5480-0c57-11ea-8da9-554b98a0176e.png)


I don't have the experience to understand if what I did was wrong or if there was a better way to do it, so I hope to learn a bit to achieve these results. However, if these were NOT the results that we wanted to begin with, then I totally understand if you disregard this PR. :D