### PR TITLE
Tweak syntax highlighting

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -4865,13 +4865,11 @@ syn match terraBraces        "[\[\]]"
 """ skip \" in strings.
 """ we may also want to pass \\" into a function to escape quotes.
 syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStringInterp
-syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction,terraValueVarSubscript,terraStringInterp contained
+syn region terraStringInterp  matchgroup=terraBraces start=/\${/ end=/}/ contained contains=ALL
 syn region terraHereDocText   start=/<<-\?\z([a-z0-9A-Z]\+\)/ end=/^\s*\z1/ contains=terraStringInterp
+
 "" TODO match keywords here, not a-z+
-syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
-" User variables or module outputs can be lists or maps, and accessed with
-" var.map["foo"]
-syn region terraValueVarSubscript start=/\(\<var\|\<module\)\.[a-z0-9_-]\+\[/ end=/\]/ contains=terraValueString,terraValueFunction,terraValueVarSubscript contained
+syn match terraValueFunction "[a-z]\+(\@="
 
 """ HCL2
 syn keyword terraContent        content
@@ -4890,7 +4888,6 @@ syn region terraBlock matchgroup=terraBraces start="{" end="}" fold transparent
 
 hi def link terraComment           Comment
 hi def link terraTodo              Todo
-hi def link terraBrackets          Operator
 hi def link terraProvider          Structure
 hi def link terraBraces            Delimiter
 hi def link terraProviderName      String
@@ -4903,7 +4900,6 @@ hi def link terraDataName          String
 hi def link terraDataTypeBI        Tag
 hi def link terraDataTypeStr       String
 hi def link terraSection           Structure
-hi def link terraStringInterp      Identifier
 hi def link terraValueBool         Boolean
 hi def link terraValueDec          Number
 hi def link terraValueHexaDec      Number
@@ -4913,7 +4909,7 @@ hi def link terraProvisioner       Structure
 hi def link terraProvisionerName   String
 hi def link terraModule            Structure
 hi def link terraModuleName        String
-hi def link terraValueFunction     Identifier
+hi def link terraValueFunction     Function
 hi def link terraValueVarSubscript Identifier
 hi def link terraDynamic           Structure
 hi def link terraDynamicName       String

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -9,7 +9,7 @@ Given terraform (user maps):
 Execute (syntax is good):
   AssertEqual 'terraStringInterp', SyntaxOf('count.index')
 
-  " Check it closed the string and wnet back to normal mode properly.
+  " Check it closed the string and went back to normal mode properly.
   AssertEqual 'terraComment', SyntaxOf('Comment')
 
 
@@ -26,7 +26,7 @@ CMD # Comment
 ;
 
 Execute (syntax is good):
-  AssertEqual 'terraStringInterp', SyntaxOf('aws_instance')
+  AssertEqual 'terraResourceTypeBI', SyntaxOf('aws_instance')
   AssertEqual 'terraHereDocText', SyntaxOf('my_command')
 
   " Closing CMD is still here doc


### PR DESCRIPTION
Attempt to improve the treatment of interpolated strings, and functions:

- un-highlight the terraStringInterp region, and un-restrict the things
  that it can contain
- don't treat terraValueFunction as a region, just highlight the
  function name

The intention is that things inside interpolated strings, and arguments
to functions, just get their regular highlighting