### PR TITLE
Put the autocmd filetypedetect in an augroup

### DIFF
--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,5 +1,8 @@
 " By default, Vim associates .tf files with TinyFugue - tell it not to.
-autocmd! filetypedetect BufRead,BufNewFile *.tf
+augroup filetypedetect
+  au BufRead,BufNewFile *.tf set filetype=terraform
+augroup END
+
 autocmd BufRead,BufNewFile *.tf set filetype=terraform
 autocmd BufRead,BufNewFile *.tfvars set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate set filetype=json


### PR DESCRIPTION
I use this plugin with NeoVim on the NixOS Linux distribution. 657cf09ff3a53388cee2cfabdbe44512f9f60e4d has broken NeoVim for me because this plugin is loaded before the `filetypedetect` event is defined. Below is the error that I get when I open vim without this change:

```
Error detected while processing /nix/store/37njws9gkfz3w5q1mm9kf3fcbd58lwqs-vimplugin-vim-terraform-2019-12-16/share/vim-plugins/vim-terraform/ftdetect/terraform.vim:                                                                                                           
line    2:                                                                                                                                                                                                                                                                       
E216: No such group or event: filetypedetect BufRead,BufNewFile *.tf
```

This was reported downstream: https://github.com/NixOS/nixpkgs/issues/65894 and a workaround was applied in https://github.com/NixOS/nixpkgs/pull/66536. This should fix the issue.