### PR TITLE
Silence any errors clearing TinyFugue association

### DIFF
--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,5 +1,5 @@
 " By default, Vim associates .tf files with TinyFugue - tell it not to.
-autocmd! filetypedetect BufRead,BufNewFile *.tf
+silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
 autocmd BufRead,BufNewFile *.tf set filetype=terraform
 autocmd BufRead,BufNewFile *.tfvars set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate set filetype=json


### PR DESCRIPTION
See #133.  I'm not fully convinced that this should be necessary, but it
certainly ought to be harmless.