### PR TITLE
Fix illegal option error in find

### DIFF
--- a/get_providers.sh
+++ b/get_providers.sh
@@ -23,7 +23,7 @@ function get_providers() {
                 git clone --depth 1 https://github.com/terraform-providers/${REPO}
                 # Only get the folder/files we need. There's probably a better way checkout only the files we need, but I don't know it.
                 cd ${REPO}
-                find -type f -not -name "*provider*.go" -delete
+                find . -type f -not -name "*provider*.go" -delete
                 cd ..
             else
                 cd ${REPO}


### PR DESCRIPTION
On OSX, not having a path argument results in an error with the use of `-not`.

```
$ find . -type f -not -name "*provider*" 1>/dev/null
$ find -type f -not -name "*provider*" 1>/dev/null
find: illegal option -- t
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```

```
Updating files: 100% (2597/2597), done.
find: illegal option -- t
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
Cloning into 'terraform-provider-acme'...
```