### PR TITLE
add support for hcl file extensions

### DIFF
--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,6 +1,7 @@
 " By default, Vim associates .tf files with TinyFugue - tell it not to.
 silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
 autocmd BufRead,BufNewFile *.tf set filetype=terraform
+autocmd BufRead,BufNewFile *.hcl set filetype=terraform
 autocmd BufRead,BufNewFile *.tfvars set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate set filetype=json
 autocmd BufRead,BufNewFile *.tfstate.backup set filetype=json

--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -53,6 +53,7 @@ if get(g:, 'terraform_fmt_on_save', 0)
   augroup vim.terraform.fmt
     autocmd!
     autocmd BufWritePre *.tf call terraform#fmt()
+    autocmd BufWritePre *.hcl call terraform#fmt()
     autocmd BufWritePre *.tfvars call terraform#fmt()
   augroup END
 endif


### PR DESCRIPTION
Terragrunt uses the .hcl extension for configuring its tool, which
follows the HCL syntax. There is a terragrunt hclfmt command, but
it doesn't properly support stdin/stdout yet (though I have an
open issue for this on that repo).

In the short term, the terraform fmt command should be sufficient,
so this PR adds support for binding hcl files for this.