### PR TITLE
Drop the filereadable check before formatting

### DIFF
--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -5,9 +5,6 @@ set cpoptions&vim
 let $TF_CLI_ARGS_fmt=''
 
 function! terraform#fmt()
-  if !filereadable(expand('%:p'))
-    return
-  endif
   let l:curw = winsaveview()
   " Make a fake change so that the undo point is right.
   normal! ix


### PR DESCRIPTION
I _think_ this is unnecessary, and it should fix #138.