### PR TITLE
Fix logging saved to file on fmt if $TF_LOG in use

### DIFF
--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -3,6 +3,7 @@ set cpoptions&vim
 
 " Ensure no conflict with arguments from the environment
 let $TF_CLI_ARGS_fmt=''
+let $TF_LOG=''
 
 function! terraform#fmt()
   if !filereadable(expand('%:p'))


### PR DESCRIPTION
If the environment variable `TF_LOG` is set to something non-empty (e.g.
`'trace'`) when vim is launched, this will cause the log output to be
rendered in the buffer and saved to the top of the file on fmt.

This commit fixes the issue by ensuring that `$TF_LOG` is clear before
fmt is called.