### PR TITLE
Fix indentation for block comments

### DIFF
--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -48,12 +48,12 @@ function! TerraformIndent(lnum)
   endif
 
   " If the previous line starts a block comment /*, increase by one
-  if prevline =~ '/\*'
+  if prevline =~# '/\*'
     let thisindent += 1
   endif
 
   " If the previous line ends a block comment */, decrease by one
-  if prevline =~ '\*/'
+  if prevline =~# '\*/'
     let thisindent -= 1
   endif
 

--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -47,6 +47,16 @@ function! TerraformIndent(lnum)
     let thisindent -= &shiftwidth
   endif
 
+  " If the previous line starts a block comment /*, increase by one
+  if prevline =~ '/\*'
+    let thisindent += 1
+  endif
+
+  " If the previous line ends a block comment */, decrease by one
+  if prevline =~ '\*/'
+    let thisindent -= 1
+  endif
+
   return thisindent
 endfunction
 


### PR DESCRIPTION
This PR fixes indentation for block comments.

Previously, when typing out a block comment, you'd get this:
```
/*
*
*/
foo

# and if you fixed it manually you'd get this:
/*
 *
 */
 foo # note that this line is too indented
```
instead of this:
```
/*
 *
 */
foo
```
