### PR TITLE
fix: set expandtab so that newlines respect indent

### DIFF
--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -8,11 +8,11 @@ let s:cpo_save = &cpoptions
 set cpoptions&vim
 
 setlocal nolisp
-setlocal autoindent shiftwidth=2 tabstop=2 softtabstop=2
+setlocal autoindent shiftwidth=2 tabstop=2 softtabstop=2 expandtab
 setlocal indentexpr=TerraformIndent(v:lnum)
 setlocal indentkeys+=<:>,0=},0=)
 let b:undo_indent = 'setlocal lisp< autoindent< shiftwidth< tabstop< softtabstop<'
-  \ . ' indentexpr< indentkeys<'
+  \ . ' expandtab< indentexpr< indentkeys<'
 
 let &cpoptions = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
I've for a long time been dealing with issues when using heredocs and
tabs.  Today I notice that it too inserted tabs when creating newlines
inside a resource.  Have never really been bothers by it as these got
changed to spaces after running `terraform fmt`.  However, as said, I
noticed that this occurred more places and needed to look for a fix.

By explicitly setting `expandtab`, we make sure that Vim uses spaces
instead of tabs when we press enter to insert a newline.

---

I find it strange that no one else has had this issue?  I did disable all of my plugins to make sure that I did not interfere.