### PR TITLE
Support .hcl extension for highlighting

### DIFF
--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,4 +1,4 @@
 " By default, Vim associates .tf files with TinyFugue - tell it not to.
 silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
-autocmd BufRead,BufNewFile *.tf,*.tfvars,.terraformrc,terraform.rc set filetype=terraform
+autocmd BufRead,BufNewFile *.hcl,*.tf,*.tfvars,.terraformrc,terraform.rc set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate,*.tfstate.backup set filetype=json


### PR DESCRIPTION
Terragrunt user writes a lot of files with .hcl extension that contains HCL content.
Adding the .hcl extension allows to open these files with the HCL highlighting