### PR TITLE
Allow no indentation of heredoc strings

### DIFF
--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -30,13 +30,19 @@ function! TerraformIndent(lnum)
     return 0
   endif
 
-  " Usual case is to continue at the same indent as the previous non-blank line.
   let prevlnum = prevnonblank(a:lnum-1)
-  let thisindent = indent(prevlnum)
+  let prevline = getline(prevlnum)
 
+  " If the previous line is starts a non-indented heredoc string e.g. <<EOF
+  " then there should usually be no indent (skipped by default)
+  if g:terraform_unindent_heredoc && prevline =~? '<<[A-Z]\+$'
+    return 0
+  endif
+
+  " Usual case is to continue at the same indent as the previous non-blank line.
+  let thisindent = indent(prevlnum)
   " If that previous line is a non-comment ending in [ { (, increase the
   " indent level.
-  let prevline = getline(prevlnum)
   if prevline !~# '^\s*\(#\|//\)' && prevline =~# '[\[{\(]\s*$'
     let thisindent += &shiftwidth
   endif


### PR DESCRIPTION
Standard heredocs, e.g. `<<EOF` followed by a multiline string, often
require zero indentation on the first line of the string content,
otherwise spaces will be inserted. Leading spaces may be problematic in
certain common use-cases, such as in-line JSON. Ensuring zero
indentation for the first line of heredoc string literals may be enabled
by setting `g:terraform_unindent_heredoc = 1`

The default behaviour is not changed since there may be cases when
string literals with leading spaces are intentional. Heredoc strings
with the optional hyphen e.g. `<<-EOF` should be indented as for the
previous line and are unaffected.