### PR TITLE
Add support for general HCL files as well

### DIFF
--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,4 +1,4 @@
 " By default, Vim associates .tf files with TinyFugue - tell it not to.
 silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
-autocmd BufRead,BufNewFile *.tf,*.tfvars,.terraformrc,terraform.rc,*.hcl set filetype=terraform
+autocmd BufRead,BufNewFile *.tf,*.tfvars,*.hcl,.terraformrc,terraform.rc set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate,*.tfstate.backup set filetype=json

--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,4 +1,4 @@
 " By default, Vim associates .tf files with TinyFugue - tell it not to.
 silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
-autocmd BufRead,BufNewFile *.tf,*.tfvars,.terraformrc,terraform.rc set filetype=terraform
+autocmd BufRead,BufNewFile *.tf,*.tfvars,.terraformrc,terraform.rc,*.hcl set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate,*.tfstate.backup set filetype=json

--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -60,6 +60,7 @@ if get(g:, 'terraform_fmt_on_save', 0)
     autocmd!
     autocmd BufWritePre *.tf call terraform#fmt()
     autocmd BufWritePre *.tfvars call terraform#fmt()
+    autocmd BufWritePre *.hcl call terraform#fmt()
   augroup END
 endif
 

--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -19,7 +19,7 @@ syn case match
 " A block is introduced by a type, some number of labels - which are either
 " strings or identifiers - and an opening curly brace.  Match the type.
 syn match terraBlockIntroduction /^\s*\zs\K\k*\ze\s\+\(\("\K\k*"\|\K\k*\)\s\+\)*{/ contains=terraBlockType
-syn keyword terraBlockType contained data locals module output provider resource terraform variable
+syn keyword terraBlockType contained data locals module output provider resource terraform variable source build
 
 syn keyword terraValueBool true false on off yes no
 


### PR DESCRIPTION
What?

Adding support for general HCL files.

Why?

Since Terraform is written in HCL and the HCL is growing its popularity among other tooling I think it would be great if we can reuse the awesome work you did over them. In particular, I am talking about Packer image build templates. I am using Terraform and Packer extensively and if you write Packer with HCL then reusing the vim plugin is pretty convenient.

PS: I am totally fine with rejecting the PR, but it works for me and I am glad to use it as part of the origin repo. Otherwise, I will fallback on my vim configuration to use my fork and sync my fork with yours from time to time!

I did an amazing job anyway! ❤️ 