### PR TITLE
add hcl to filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For example to use this plugin for files with suffix `.hcl`, put the following
 in `~/.vim/ftdetect/terraform.vim`:
 
 ```viml
-autocmd BufRead,BufNewFile *.hcl set filetype=terraform
+autocmd BufRead,BufNewFile *.hcl set filetype=hcl.terraform
 ```
 
 ---

--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,5 +1,5 @@
 " vint: -ProhibitAutocmdWithNoGroup
 " By default, Vim associates .tf files with TinyFugue - tell it not to.
 silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
-autocmd BufRead,BufNewFile *.tf,*.tfvars,.terraformrc,terraform.rc set filetype=terraform
+autocmd BufRead,BufNewFile *.tf,*.tfvars,.terraformrc,terraform.rc set filetype=hcl.terraform
 autocmd BufRead,BufNewFile *.tfstate,*.tfstate.backup set filetype=json


### PR DESCRIPTION
Add the `hcl` filetype to make terraform files work with `hcl` plugins. 

See for example: https://github.com/nvim-treesitter/nvim-treesitter/pull/1445