### PR TITLE
feat: add an option for terraform fmt on save when modified only.

### DIFF
--- a/autoload/terraform.vim
+++ b/autoload/terraform.vim
@@ -31,6 +31,23 @@ function! terraform#fmt() abort
   call winrestview(curw)
 endfunction
 
+function! terraform#fmt_on_save()
+  " Skip when "g:terraform_fmt_on_save" is disabled.
+  if get(g:, 'terraform_fmt_on_save', 0) == 0
+    return
+  endif
+
+  " Skip when "g:terraform_fmt_on_save_when_modified_only" is enabled
+  " and the current buffer is not modified.
+  if get(g:, 'terraform_fmt_on_save_when_modified_only', 0)
+    if &modified == 0
+      return
+    endif
+  endif
+
+  call terraform#fmt()
+endfunction
+
 function! terraform#commands(ArgLead, CmdLine, CursorPos) abort
   let commands = [
     \ 'init',

--- a/doc/terraform.txt
+++ b/doc/terraform.txt
@@ -33,6 +33,15 @@ SETTINGS                                                 *terraform-settings*
     terraform fmt. You can also do this manually with the `:TerraformFmt` command.
     Default: 0
 
+*g:terraform_fmt_on_save_when_modified_only*
+    Allow vim-terraform to automatically format *.tf and *.tfvars files with
+    terraform fmt only when the current buffer is modified.
+    Default: 0
+>
+  let g:terraform_fmt_on_save=1
+  let g:terraform_fmt_on_save_when_modified_only=1
+<
+
 *g:terraform_fold_sections*
     Allow vim-terraform to automatically fold (hide until unfolded) sections of
     terraform code.

--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -43,13 +43,11 @@ command! -nargs=+ -complete=custom,terraform#commands -buffer Terraform
 command! -nargs=0 -buffer TerraformFmt call terraform#fmt()
 let b:undo_ftplugin .= '|delcommand Terraform|delcommand TerraformFmt'
 
-if get(g:, 'terraform_fmt_on_save', 0)
-  augroup vim.terraform.fmt
-    autocmd!
-    autocmd BufWritePre *.tf call terraform#fmt()
-    autocmd BufWritePre *.tfvars call terraform#fmt()
-  augroup END
-endif
+augroup vim.terraform.fmt
+  autocmd!
+  autocmd BufWritePre *.tf call terraform#fmt_on_save()
+  autocmd BufWritePre *.tfvars call terraform#fmt_on_save()
+augroup END
 
 let &cpoptions = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Add an option "g:terraform_fmt_on_save_when_modified_only"
to run `terraform fmt` on save when the current buffer is modified only.

Usage:

```vim
let g:terraform_fmt_on_save=1
let g:terraform_fmt_on_save_when_modified_only=1
```
I don't want vim-terraform to automatically run `terraform fmt` when the file is not modified.