### PR TITLE
Add optional support for format on save for Terragrunt hcl files

### DIFF
--- a/ftplugin/hcl.vim
+++ b/ftplugin/hcl.vim
@@ -49,7 +49,8 @@ let b:undo_ftplugin .= '|delcommand HclFmt'
 if get(g:, 'hcl_fmt_on_save', 0)
   augroup vim.terraform.fmt
     autocmd!
-    autocmd BufWritePre *.hcl call terraform#fmt()
+    autocmd BufWritePre *.tg.hcl call terraform#fmt()
+    autocmd BufWritePre terragrunt.hcl call terraform#fmt()
   augroup END
 endif
 

--- a/ftplugin/hcl.vim
+++ b/ftplugin/hcl.vim
@@ -6,6 +6,14 @@ if exists('b:did_ftplugin') || v:version < 700 || &compatible
 endif
 let b:did_ftplugin = 1
 
+if !exists('g:terraform_binary_path')
+  let g:terraform_binary_path='terraform'
+endif
+
+if !executable(g:terraform_binary_path)
+  finish
+endif
+
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
@@ -33,6 +41,16 @@ let b:undo_ftplugin .= ' commentstring<'
 if get(g:, 'hcl_align', 0) && exists(':Tabularize')
   inoremap <buffer> <silent> = =<Esc>:call hcl#align()<CR>a
   let b:undo_ftplugin .= '|iunmap <buffer> ='
+endif
+
+command! -nargs=0 -buffer HclFmt call terraform#fmt()
+let b:undo_ftplugin .= '|delcommand HclFmt'
+
+if get(g:, 'hcl_fmt_on_save', 0)
+  augroup vim.terraform.fmt
+    autocmd!
+    autocmd BufWritePre *.hcl call terraform#fmt()
+  augroup END
 endif
 
 let &cpoptions = s:cpo_save


### PR DESCRIPTION
I use this plugin every day. I love this plugin. I use it for work and it makes maintaining repository consistency a breeze. Lately I've been leaning more and more into Terragrunt which uses a similar syntax to plain Terraform. So much so that the official `terragrunt hclfmt` tool uses Hashicorp's own `hclfmt` with some additional safeties. (https://github.com/gruntwork-io/terragrunt/issues/1037#issuecomment-723134750) While the syntax is basically the same, this plugin has resolved previously to not support Terragrunt.

I know there has been some animosity shared between this repo and the Terraform repo in maintaining third party tooling in cohesion with vanilla Terraform. See #165. I understand this resistance but here are a few reasons this should be considered.
 - The format tool itself in the backend is the same and follows the same syntax (https://github.com/gruntwork-io/terragrunt/issues/1037#issuecomment-723134750)
 - The two tools are always used in unison. Terragrunt does not exist without Terraform.
 - A known bug with this plugin prevents Tabular integration from properly indenting `*.hcl` files to format spec. (#164)
 - There are many other attempts at implementations of this plugin for Terragrunt. They usually suffer from poor/no maintenance, lack of experience, and fragmentation. (https://github.com/yorinasub17/vim-terragrunt , https://github.com/rhadley-recurly/vim-terragrunt)
 - Terragrunt's formatting tool cannot yet read from stdin. It's current implementation is as a post processor that reads only individual files or entire projects. (https://github.com/gruntwork-io/terragrunt/issues/1037)
 - This difference in file handling is confusing to newcomers as Terragrunt HCL files and Terraform HCL files are essentially the same but one can be configured to automatically format and the other can't. There is no warning about this and the practical change didn't go noticed by me for quite some time.
 
 At this point in time, Terraform and Terragrunt formatting is the same and uses the same tooling. Forcing this capability to be put in a separate plugin creates further fragmentation and enables a less mature + poorer implementation overall.

The implementation I have provided copies directly from the same function for Terraform files and is by default disabled.

I'm no Lua developer. Feel free to point and judge. :)
