### PR TITLE
Add Vim-plug/Packer/Lazy install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ With [Vundle](https://github.com/VundleVim/Vundle.vim), add the following to `~/
 
     Plugin 'hashivim/vim-terraform'
 
+With [Vim-plug](https://github.com/junegunn/vim-plug), add the following to `~/.vimrc`:
+
+    Plug 'hashivim/vim-terraform'
+
+With [Lazy.nvim](https://github.com/folke/lazy.nvim), add the following to `init.lua`:
+```lua
+{ "hashivim/vim-terraform", ft = "terraform", cmd = {"Terraform", "TerraformFmt"} },
+```
+
+With [Packer.nvim](https://github.com/wbthomason/packer.nvim), add the following to `init.lua`:
+```lua
+use { "hashivim/vim-terraform" },
+```
 ---
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -32,19 +32,24 @@ With [Vundle](https://github.com/VundleVim/Vundle.vim), add the following to `~/
 
     Plugin 'hashivim/vim-terraform'
 
-With [Vim-plug](https://github.com/junegunn/vim-plug), add the following to `~/.vimrc`:
+<details>
+  <summary>...</summary>
 
-    Plug 'hashivim/vim-terraform'
+  With [Vim-plug](https://github.com/junegunn/vim-plug), add the following to `~/.vimrc`:
 
-With [Lazy.nvim](https://github.com/folke/lazy.nvim), add the following to `init.lua`:
-```lua
-{ "hashivim/vim-terraform", ft = "terraform", cmd = {"Terraform", "TerraformFmt"} },
-```
+      Plug 'hashivim/vim-terraform'
 
-With [Packer.nvim](https://github.com/wbthomason/packer.nvim), add the following to `init.lua`:
-```lua
-use { "hashivim/vim-terraform" },
-```
+  With [Lazy.nvim](https://github.com/folke/lazy.nvim), add the following to `init.lua`:
+  ```lua
+  { "hashivim/vim-terraform", ft = "terraform" },
+  ```
+
+  With [Packer.nvim](https://github.com/wbthomason/packer.nvim), add the following to `init.lua`:
+  ```lua
+  use { "hashivim/vim-terraform" },
+  ```
+</details>
+
 ---
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,34 +20,11 @@ files to be highlighted as HCL and `*.tfstate` as JSON.
 
 ## Installation
 
-With [Vim 8 packages](http://vimhelp.appspot.com/repeat.txt.html#packages):
+With [Vim packages](http://vimhelp.appspot.com/repeat.txt.html#packages):
 
     git clone https://github.com/hashivim/vim-terraform.git ~/.vim/pack/plugins/start/vim-terraform
 
-With [Pathogen](https://github.com/tpope/vim-pathogen):
-
-    git clone https://github.com/hashivim/vim-terraform.git ~/.vim/bundle/vim-terraform
-
-With [Vundle](https://github.com/VundleVim/Vundle.vim), add the following to `~/.vimrc`:
-
-    Plugin 'hashivim/vim-terraform'
-
-<details>
-  <summary>...</summary>
-
-  With [Vim-plug](https://github.com/junegunn/vim-plug), add the following to `~/.vimrc`:
-
-      Plug 'hashivim/vim-terraform'
-
-  With [Lazy.nvim](https://github.com/folke/lazy.nvim), add the following to `init.lua`:
-  ```lua
-  { "hashivim/vim-terraform", ft = "terraform" },
-  ```
-
-  With [Packer.nvim](https://github.com/wbthomason/packer.nvim), add the following to `init.lua`:
-  ```lua
-  use { "hashivim/vim-terraform" },
-  ```
+If you prefer to use a plugin manager, go ahead.
 </details>
 
 ---


### PR DESCRIPTION
A little PR to add 3 classic vim package managers: Vim-plug, Packer and Lazy.  
The arguments for Lazy.nvim allow lazy-loading, meaning the plugin will only be loaded on Terraform files or when the commands are used.