### PR TITLE
Broaden hcl function regex

### DIFF
--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -41,7 +41,7 @@ syn region hclStringInterp  matchgroup=hclBraces start=/\(^\|[^$]\)\$\zs{/ end=/
 syn region hclHereDocText   start=/<<-\?\z([a-z0-9A-Z]\+\)/ end=/^\s*\z1/ contains=hclStringInterp
 
 "" Functions.
-syn match hclFunction "[a-z0-9]\+(\@="
+syn match hclFunction "\w\+(\@="
 
 """ HCL2
 syn keyword hclRepeat         for in


### PR DESCRIPTION
[HCL syntax spec](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#identifiers) states that identifiers are:

```ebnf
Identifier = ID_Start (ID_Continue | '-')*;
```

([here](https://unicode.org/reports/tr31/#Figure_Code_Point_Categories_for_Identifier_Parsing) are unicode specifications for `ID_Start` and `ID_Continue`)

My change makes it closer to the specification, considering that perfection is unrealistic to achieve without vim's support of unicode groups in regex.

I need the change because I use `hcl` along with the official `userfunc` extension and define lots of functions in my config files. The underscore is very handy in this situation, but it wasn't supported before.