### PR TITLE
add: enabled format for `*.tftest.hcl` files

### DIFF
--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -48,6 +48,7 @@ if get(g:, 'terraform_fmt_on_save', 0)
     autocmd!
     autocmd BufWritePre *.tf call terraform#fmt()
     autocmd BufWritePre *.tfvars call terraform#fmt()
+    autocmd BufWritePre *.tftest.hcl call terraform#fmt()
   augroup END
 endif
 


### PR DESCRIPTION
Hi, I added file format for testing framework to `terraform_fmt_on_save`.
ref. https://github.com/hashicorp/terraform/pull/33576
