### PR TITLE
Recommend use '# %s' instead of '#%s' as commentstring

### DIFF
--- a/ftplugin/hcl.vim
+++ b/ftplugin/hcl.vim
@@ -27,7 +27,7 @@ if get(g:, 'hcl_fold_sections', 0)
 endif
 
 " Set the commentstring
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 let b:undo_ftplugin .= ' commentstring<'
 
 if get(g:, 'hcl_align', 0) && exists(':Tabularize')


### PR DESCRIPTION
Recommend use '# %s' instead of '#%s' as commentstring. This will make the comment string look more aesthetically pleasing, which is also the practice of other editors.

like helix:

![2024-05-02 22 29 02](https://github.com/hashivim/vim-terraform/assets/36906329/10ef47b3-cb0a-4f6b-a9bf-5d2f5f08ed33)


like vscode, with [vscode-terraform](https://github.com/hashicorp/vscode-terraform) plugin:

![2024-05-02 22 32 48](https://github.com/hashivim/vim-terraform/assets/36906329/6468349e-8daa-4f52-b3de-a84940f14d7c)


like Jetbrains IDEs, e.g. Goland:

![2024-05-02 22 33 30](https://github.com/hashivim/vim-terraform/assets/36906329/c93bef81-09e1-415d-b153-38faf651ea5b)



If disagreed, please feel free to close this PR