### PR TITLE
Add .tofu and .tofutest.hcl to list of extensions

### DIFF
--- a/ftdetect/hcl.vim
+++ b/ftdetect/hcl.vim
@@ -3,5 +3,5 @@
 silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
 autocmd BufRead,BufNewFile *.hcl,*.tfbackend set filetype=hcl
 autocmd BufRead,BufNewFile .terraformrc,terraform.rc set filetype=hcl
-autocmd BufRead,BufNewFile *.tf,*.tfvars,*.tftest.hcl set filetype=terraform
+autocmd BufRead,BufNewFile *.tf,*.tofu,*.tfvars,*.tftest.hcl set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate,*.tfstate.backup set filetype=json

--- a/ftdetect/hcl.vim
+++ b/ftdetect/hcl.vim
@@ -3,5 +3,5 @@
 silent! autocmd! filetypedetect BufRead,BufNewFile *.tf
 autocmd BufRead,BufNewFile *.hcl,*.tfbackend set filetype=hcl
 autocmd BufRead,BufNewFile .terraformrc,terraform.rc set filetype=hcl
-autocmd BufRead,BufNewFile *.tf,*.tofu,*.tfvars,*.tftest.hcl set filetype=terraform
+autocmd BufRead,BufNewFile *.tf,*.tofu,*.tfvars,*.tftest.hcl,*.tofutest.hcl set filetype=terraform
 autocmd BufRead,BufNewFile *.tfstate,*.tfstate.backup set filetype=json


### PR DESCRIPTION
OpenTofu 1.8 adds support for [`.tofu` files](https://opentofu.org/docs/intro/whats-new/#override-files-for-opentofu-keeping-compatibility) which override `.tf` files of the same name. The syntax is still the same, so we can apply the usual `terraform` filetype configuration to these files as well.