### PR TITLE
add underscore to HCL function identifier regex

### DIFF
--- a/syntax/hcl.vim
+++ b/syntax/hcl.vim
@@ -41,7 +41,7 @@ syn region hclStringInterp  matchgroup=hclBraces start=/\(^\|[^$]\)\$\zs{/ end=/
 syn region hclHereDocText   start=/<<-\?\z([a-z0-9A-Z]\+\)/ end=/^\s*\z1/ contains=hclStringInterp
 
 "" Functions.
-syn match hclFunction "[a-z0-9]\+(\@="
+syn match hclFunction "[a-z0-9_]\+(\@="
 
 """ HCL2
 syn keyword hclRepeat         for in


### PR DESCRIPTION
As titled. While I realize that this is similar to #185 which was closed, I believe that just adding the underscore will keep the regex idiomatic while covering common, real-world cases.

The HCL spec here: 
https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#identifiers

contains the following paragraph:

> The dash character `-` is additionally allowed in identifiers, even though
that is not part of the unicode `ID_Continue` definition. This is to allow
attribute names and block type names to contain dashes, although underscores
as word separators are considered the idiomatic usage.

I believe this sufficiently implies that the use of `_` as an idiomatic word-separator character in identifiers.

Additionally, we can see real-world adoption of this practice in projects like Terragrunt, which use the underscore as a word separator for built-in functions: https://terragrunt.gruntwork.io/docs/reference/built-in-functions/